### PR TITLE
Enable 3 PhoneInput E2E tests

### DIFF
--- a/e2e/phone-input.test.ts
+++ b/e2e/phone-input.test.ts
@@ -38,12 +38,7 @@ test.describe('PhoneInput', () => {
 		await expect(page.getByPlaceholder('Search country...')).not.toBeVisible();
 	});
 
-	// KNOWN BUG: PhoneInput value binding broken — phoneValue stays null after typing
-	// due to Svelte 4/5 interop issue with svelte-tel-input. The `valid` state never
-	// becomes true so the submit button stays disabled.
-	// Fix: phone-input.svelte should initialize value = $bindable('') instead of null.
-	// See: .claude/projects/.../memory/project_playwright_test_notes.md BUG 1
-	test.fixme('valid PT number enables submit and hides or-divider', async ({ page }) => {
+	test('valid PT number enables submit and hides or-divider', async ({ page }) => {
 		await page.locator('input[type="tel"]').fill('912345678');
 		await expect(page.getByRole('button', { name: 'Send code' })).toBeEnabled();
 		await expect(page.getByText('or', { exact: true })).not.toBeVisible();
@@ -52,14 +47,12 @@ test.describe('PhoneInput', () => {
 		).not.toBeVisible();
 	});
 
-	// KNOWN BUG: same value binding issue
-	test.fixme('partial number keeps submit disabled', async ({ page }) => {
+	test('partial number keeps submit disabled', async ({ page }) => {
 		await page.locator('input[type="tel"]').fill('123');
 		await expect(page.getByRole('button', { name: 'Send code' })).toBeDisabled();
 	});
 
-	// KNOWN BUG: same value binding issue
-	test.fixme('valid NL number enables submit after country switch', async ({ page }) => {
+	test('valid NL number enables submit after country switch', async ({ page }) => {
 		const countryBtn = page.locator('button.rounded-l-lg');
 		await countryBtn.click();
 		await page.getByPlaceholder('Search country...').fill('nether');


### PR DESCRIPTION
## Summary

- Removes `test.fixme` from 3 PhoneInput E2E tests that were skipped due to a suspected Svelte 4/5 interop bug
- No changes to production code — `phone-input.svelte` is untouched

## What we found

The `on:updateValue` / `on:updateValid` directives in `phone-input.svelte` work correctly in Svelte 5. Component `on:` directives compile to `$$events` in the child's props, which is exactly what `svelte-tel-input`'s `createEventDispatcher` reads at dispatch time. The tests were skipped based on a misdiagnosis — they pass as-is.

(The suggested fix of switching to `onupdatevalue` lowercase callback props would actually *break* things, since that bypasses `$$events` entirely.)

## Test plan

- [x] All 7 PhoneInput tests pass locally (`bunx playwright test e2e/phone-input.test.ts`)
- [x] `bun run format && bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)