### PR TITLE
Show declined feedback to QR initiator

### DIFF
--- a/e2e/send-receive.test.ts
+++ b/e2e/send-receive.test.ts
@@ -71,6 +71,80 @@ test.describe.serial('Send / Receive flow', () => {
 		}
 	});
 
+	test('send: receiver declines shows declined feedback to sender', async ({
+		browser
+	}, testInfo) => {
+		const baseURL = testInfo.project.use.baseURL!;
+		const senderCtx = await browser.newContext({ storageState: senderStorage, baseURL });
+		const receiverCtx = await browser.newContext({ storageState: receiverStorage, baseURL });
+		const senderPage = await senderCtx.newPage();
+		const receiverPage = await receiverCtx.newPage();
+
+		try {
+			// ── Sender: consent already given, go straight to amount ──────────────
+			await goto(senderPage, '/send');
+			await expect(senderPage.getByRole('heading', { name: 'Send' })).toBeVisible();
+			await senderPage.locator('input[name="amount"]').fill('5.00');
+			await senderPage.getByRole('button', { name: 'Generate QR' }).click();
+
+			// ── Sender: QR step — extract accept URL ─────────────────────────────
+			const urlText = senderPage.getByText(/\/accept\//);
+			await expect(urlText).toBeVisible({ timeout: 10_000 });
+			const acceptUrl = (await urlText.textContent())!.trim();
+
+			// ── Receiver: decline the send QR ─────────────────────────────────────
+			await goto(receiverPage, acceptUrl);
+			await expect(receiverPage.getByRole('heading', { level: 1 })).toContainText(
+				`${SENDER_NAME} wants to send you`
+			);
+			await receiverPage.getByRole('button', { name: 'Decline' }).click();
+			await expect(receiverPage).toHaveURL(/\/home/, { timeout: 10_000 });
+
+			// ── Sender: polling detects decline ───────────────────────────────────
+			await expect(senderPage.getByText(/declined/i)).toBeVisible({ timeout: 10_000 });
+		} finally {
+			await senderCtx.close();
+			await receiverCtx.close();
+		}
+	});
+
+	test('receive: payer declines shows declined feedback to initiator', async ({
+		browser
+	}, testInfo) => {
+		const baseURL = testInfo.project.use.baseURL!;
+		const initiatorCtx = await browser.newContext({ storageState: receiverStorage, baseURL });
+		const payerCtx = await browser.newContext({ storageState: senderStorage, baseURL });
+		const initiatorPage = await initiatorCtx.newPage();
+		const payerPage = await payerCtx.newPage();
+
+		try {
+			// ── Initiator: amount ─────────────────────────────────────────────────
+			await goto(initiatorPage, '/receive');
+			await expect(initiatorPage.getByRole('heading', { name: 'Receive' })).toBeVisible();
+			await initiatorPage.locator('input[name="amount"]').fill('3.00');
+			await initiatorPage.getByRole('button', { name: 'Generate QR' }).click();
+
+			// ── Initiator: QR step — extract accept URL ───────────────────────────
+			const urlText = initiatorPage.getByText(/\/accept\//);
+			await expect(urlText).toBeVisible({ timeout: 10_000 });
+			const acceptUrl = (await urlText.textContent())!.trim();
+
+			// ── Payer: decline the receive QR ─────────────────────────────────────
+			await goto(payerPage, acceptUrl);
+			await expect(payerPage.getByRole('heading', { level: 1 })).toContainText(
+				`${RECEIVER_NAME} is requesting`
+			);
+			await payerPage.getByRole('button', { name: 'Decline' }).click();
+			await expect(payerPage).toHaveURL(/\/home/, { timeout: 10_000 });
+
+			// ── Initiator: polling detects decline ────────────────────────────────
+			await expect(initiatorPage.getByText(/declined/i)).toBeVisible({ timeout: 10_000 });
+		} finally {
+			await initiatorCtx.close();
+			await payerCtx.close();
+		}
+	});
+
 	test('receive: initiator requests payment and payer accepts', async ({ browser }, testInfo) => {
 		// Test Receiver initiates a receive QR; Test Sender pays.
 		const baseURL = testInfo.project.use.baseURL!;

--- a/messages/de.json
+++ b/messages/de.json
@@ -103,6 +103,7 @@
 	"send_qr_expired": "Abgelaufen — tippe, um zurückzugehen.",
 	"send_cancel": "Abbrechen",
 	"send_done": "Fertig. Du hast {amount} an {name} gesendet.",
+	"send_declined": "Dein Kredit wurde abgelehnt.",
 	"send_back_home": "Zurück zur Startseite",
 
 	"receive_helper": "Gib den Betrag ein, den du anfordern möchtest.",
@@ -110,6 +111,7 @@
 	"receive_cta": "QR generieren",
 	"receive_qr_caption": "Bitte die andere Person, dies zu scannen, um dir Kredit zu senden.",
 	"receive_done": "Fertig. Du hast {amount} von {name} erhalten.",
+	"receive_declined": "Deine Zahlungsanfrage wurde abgelehnt.",
 	"receive_back_home": "Zurück zur Startseite",
 
 	"accept_send_prompt": "{name} möchte dir {amount} senden",

--- a/messages/en.json
+++ b/messages/en.json
@@ -103,6 +103,7 @@
 	"send_qr_expired": "Expired — tap to go back.",
 	"send_cancel": "Cancel",
 	"send_done": "Done. You sent {amount} to {name}.",
+	"send_declined": "Your credit was declined.",
 	"send_back_home": "Back to home",
 
 	"receive_helper": "Enter the amount you'd like to request.",
@@ -110,6 +111,7 @@
 	"receive_cta": "Generate QR",
 	"receive_qr_caption": "Ask the other person to scan this to send you credit.",
 	"receive_done": "Done. You received {amount} from {name}.",
+	"receive_declined": "Your payment request was declined.",
 	"receive_back_home": "Back to home",
 
 	"accept_send_prompt": "{name} wants to send you {amount}",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -103,6 +103,7 @@
 	"send_qr_expired": "Verlopen — tik om terug te gaan.",
 	"send_cancel": "Annuleren",
 	"send_done": "Klaar. Je hebt {amount} gestuurd naar {name}.",
+	"send_declined": "Je krediet is geweigerd.",
 	"send_back_home": "Terug naar home",
 
 	"receive_helper": "Voer het bedrag in dat je wilt vragen.",
@@ -110,6 +111,7 @@
 	"receive_cta": "QR genereren",
 	"receive_qr_caption": "Vraag de andere persoon om dit te scannen om je krediet te sturen.",
 	"receive_done": "Klaar. Je hebt {amount} ontvangen van {name}.",
+	"receive_declined": "Je betalingsverzoek is geweigerd.",
 	"receive_back_home": "Terug naar home",
 
 	"accept_send_prompt": "{name} wil je {amount} sturen",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -103,6 +103,7 @@
 	"send_qr_expired": "Expirado — toca para voltar.",
 	"send_cancel": "Cancelar",
 	"send_done": "Feito. Enviaste {amount} a {name}.",
+	"send_declined": "O teu crédito foi recusado.",
 	"send_back_home": "Voltar ao início",
 
 	"receive_helper": "Introduz o montante que queres pedir.",
@@ -110,6 +111,7 @@
 	"receive_cta": "Gerar QR",
 	"receive_qr_caption": "Pede à outra pessoa para digitalizar isto e enviar-te crédito.",
 	"receive_done": "Feito. Recebeste {amount} de {name}.",
+	"receive_declined": "O teu pedido de pagamento foi recusado.",
 	"receive_back_home": "Voltar ao início",
 
 	"accept_send_prompt": "{name} quer enviar-te {amount}",

--- a/src/routes/(app)/receive/+page.svelte
+++ b/src/routes/(app)/receive/+page.svelte
@@ -14,7 +14,7 @@
 
 	let { data, form } = $props();
 
-	type ReceiveStep = 'amount' | 'qr' | 'done';
+	type ReceiveStep = 'amount' | 'qr' | 'done' | 'declined';
 	let step = $state<ReceiveStep>('amount');
 
 	let amount = $state('');
@@ -71,6 +71,9 @@
 					completedName = json.otherName || '';
 					completedAmount = json.formattedAmount || '';
 					step = 'done';
+				} else if (json.status === 'declined') {
+					clearInterval(pollInterval!);
+					step = 'declined';
 				}
 			} catch {
 				// ignore
@@ -183,6 +186,19 @@
 					</Button>
 				</form>
 			{/if}
+		</div>
+	{/if}
+
+	<!-- Declined step -->
+	{#if step === 'declined'}
+		<div class="flex flex-1 flex-col items-center justify-center text-center">
+			<div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 text-3xl">
+				✕
+			</div>
+			<p class="mb-6 text-lg font-medium">{m.receive_declined()}</p>
+			<Button class="w-full rounded-xl bg-[#2D4A32] py-6 text-white" onclick={() => goto('/home')}>
+				{m.receive_back_home()}
+			</Button>
 		</div>
 	{/if}
 

--- a/src/routes/(app)/send/+page.svelte
+++ b/src/routes/(app)/send/+page.svelte
@@ -14,7 +14,7 @@
 
 	let { data, form } = $props();
 
-	type SendStep = 'consent' | 'amount' | 'qr' | 'done';
+	type SendStep = 'consent' | 'amount' | 'qr' | 'done' | 'declined';
 	let step = $state<SendStep>(data.needsConsent ? 'consent' : 'amount');
 
 	let amount = $state('');
@@ -75,6 +75,9 @@
 					completedName = data.otherName || '';
 					completedAmount = data.formattedAmount || '';
 					step = 'done';
+				} else if (data.status === 'declined') {
+					clearInterval(pollInterval!);
+					step = 'declined';
 				}
 			} catch {
 				// ignore polling errors
@@ -211,6 +214,19 @@
 					</Button>
 				</form>
 			{/if}
+		</div>
+	{/if}
+
+	<!-- Declined step -->
+	{#if step === 'declined'}
+		<div class="flex flex-1 flex-col items-center justify-center text-center">
+			<div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 text-3xl">
+				✕
+			</div>
+			<p class="mb-6 text-lg font-medium">{m.send_declined()}</p>
+			<Button class="w-full rounded-xl bg-[#2D4A32] py-6 text-white" onclick={() => goto('/home')}>
+				{m.send_back_home()}
+			</Button>
 		</div>
 	{/if}
 


### PR DESCRIPTION
## Summary

- When a receiver declines a QR credit/request, the sender's polling now detects `'declined'` status and transitions to a dedicated declined step — instead of silently waiting for the countdown to expire and showing a generic "expired" message
- Adds `send_declined` / `receive_declined` i18n messages in EN, NL, PT, DE
- Adds E2E tests for both the send and receive decline flows

Fixes #12.

## Test plan

- [ ] Start a send flow, have the receiver navigate to the accept URL and click Decline — verify the sender sees "Your credit was declined." immediately
- [ ] Start a receive flow, have the payer navigate to the accept URL and click Decline — verify the initiator sees "Your payment request was declined." immediately
- [ ] Verify existing accept flows still work (CI)
- [ ] `bunx playwright test e2e/send-receive.test.ts` — all 4 tests pass once no stale server is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)