### PR TITLE
Fix OTP resend link proximity; increase default QR TTL to 3 days

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ PUBLIC_UNIT_DISPLAY_NAME=euro
 UNIT_DECIMAL_PLACES=2
 
 # ── QR codes ──
-QR_TTL_SECONDS=600
+QR_TTL_SECONDS=259200  # 3 days
 # REQUIRED: min 32 characters, used to sign QR JWTs
 QR_JWT_SECRET=change-me-to-a-random-32-char-secret!!
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,7 +23,7 @@ export const config = {
 		return parseInt(env.UNIT_DECIMAL_PLACES || '2', 10);
 	},
 	get qrTtlSeconds() {
-		return parseInt(env.QR_TTL_SECONDS || '600', 10);
+		return parseInt(env.QR_TTL_SECONDS || '259200', 10);
 	},
 	get appUrl() {
 		return env.APP_URL || 'http://localhost:5173';

--- a/src/routes/onboarding/otp/+page.svelte
+++ b/src/routes/onboarding/otp/+page.svelte
@@ -80,7 +80,7 @@
 	</div>
 
 	<!-- OTP input -->
-	<div class="relative mx-auto mb-2 flex justify-center gap-2.5">
+	<div class="relative mx-auto mb-6 flex justify-center gap-2.5">
 		<input
 			type="text"
 			inputmode="numeric"


### PR DESCRIPTION
## Summary

- Increases spacing between OTP digit boxes and the resend link (`mb-2` → `mb-6`, 8px → 24px) so it is harder to accidentally tap resend while entering a code on a touch screen. Closes #18.
- Raises the default `QR_TTL_SECONDS` from 600 s (10 min) to 259 200 s (3 days), since QR codes are often shared as links and may not be scanned immediately.

## Test plan

- [ ] Open `/onboarding/otp` on a mobile viewport — confirm visible gap between digit input and "Didn't receive it? Resend" text
- [ ] Generate a QR code without overriding `QR_TTL_SECONDS` — confirm the JWT expiry is ~3 days out
- [ ] `bun run check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)