### PR TITLE
Add E2E thread-safety note to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ Run with: `bunx playwright test` (starts dev server automatically).
 - **Hydration**: Use `goto()` from `e2e/test-utils.ts` instead of `page.goto()` — waits for `body.hydrated` before returning. bits-ui components aren't active until hydration completes.
 - **bits-ui portals**: Wait for portal content to mount after clicking a trigger (e.g. `await expect(page.getByRole('menu')).toBeVisible()`) before asserting on items inside.
 - **Do NOT** add `reducedMotion: 'reduce'` to playwright.config.ts — breaks bits-ui portal mounting.
+- **Thread safety**: Tests run in parallel locally (`fullyParallel: true`). Each test file must use unique email addresses and user identities to avoid collisions with other test files sharing the same SQLite database. Never reuse another file's email constants — define your own or use a unique prefix.
 
 ## Key Files
 


### PR DESCRIPTION
Document that parallel test files must use unique email addresses to avoid collisions on the shared SQLite database.