### PR TITLE
Add email fixture for E2E parallel safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Run with: `bunx playwright test` (starts dev server automatically).
 - **Hydration**: Use `goto()` from `e2e/test-utils.ts` instead of `page.goto()` — waits for `body.hydrated` before returning. bits-ui components aren't active until hydration completes.
 - **bits-ui portals**: Wait for portal content to mount after clicking a trigger (e.g. `await expect(page.getByRole('menu')).toBeVisible()`) before asserting on items inside.
 - **Do NOT** add `reducedMotion: 'reduce'` to playwright.config.ts — breaks bits-ui portal mounting.
-- **Thread safety**: Tests run in parallel locally (`fullyParallel: true`). Each test file must use unique email addresses and user identities to avoid collisions with other test files sharing the same SQLite database. Never reuse another file's email constants — define your own or use a unique prefix.
+- **Thread safety**: Tests run in parallel locally (`fullyParallel: true`). Use the `email` fixture (from `e2e/test-utils.ts`) in all test files — it derives unique addresses from the test filename, making collisions impossible: `email('sender')` → `e2e-{filename}-sender@test.example`. Never add shared email exports to `test-utils.ts`.
 
 ## Key Files
 

--- a/e2e/faq.test.ts
+++ b/e2e/faq.test.ts
@@ -1,7 +1,6 @@
-import { test, expect, type BrowserContext } from '@playwright/test';
-import { goto, setupAuthenticatedUser } from './test-utils.js';
+import { expect, type BrowserContext } from '@playwright/test';
+import { test, goto, setupAuthenticatedUser } from './test-utils.js';
 
-const FAQ_EMAIL = 'e2e-faq@test.example';
 const FAQ_NAME = 'FAQ User';
 
 // FAQ page is public — no auth required.
@@ -64,9 +63,9 @@ test.describe('FAQ page (public)', () => {
 test.describe('FAQ hamburger menu (authenticated)', () => {
 	let storage: Awaited<ReturnType<BrowserContext['storageState']>>;
 
-	test.beforeAll(async ({ browser }, testInfo) => {
+	test.beforeAll(async ({ browser, email }, testInfo) => {
 		const ctx = await browser.newContext({ baseURL: testInfo.project.use.baseURL! });
-		await setupAuthenticatedUser(ctx, FAQ_EMAIL, FAQ_NAME);
+		await setupAuthenticatedUser(ctx, email('user'), FAQ_NAME);
 		storage = await ctx.storageState();
 		await ctx.close();
 	});

--- a/e2e/onboarding.test.ts
+++ b/e2e/onboarding.test.ts
@@ -1,13 +1,13 @@
-import { test, expect } from '@playwright/test';
-import { goto, getOTP, deleteTestUser, clearOTPs, TEST_EMAIL } from './test-utils.js';
+import { expect } from '@playwright/test';
+import { test, goto, getOTP, deleteTestUser, clearOTPs } from './test-utils.js';
 
 test.describe.serial('Onboarding flow', () => {
-	test.afterEach(async () => {
-		await deleteTestUser(TEST_EMAIL);
+	test.afterEach(async ({ email }) => {
+		await deleteTestUser(email('user'));
 		clearOTPs();
 	});
 
-	test('complete onboarding via email — happy path', async ({ page }) => {
+	test('complete onboarding via email — happy path', async ({ page, email }) => {
 		// ── Welcome ──────────────────────────────────────────────────────────────
 		await goto(page, '/onboarding');
 		await expect(page.getByRole('heading', { name: /Together, we are more/i })).toBeVisible();
@@ -24,12 +24,12 @@ test.describe.serial('Onboarding flow', () => {
 
 		// ── Email ─────────────────────────────────────────────────────────────────
 		await expect(page).toHaveURL(/\/onboarding\/email/);
-		await page.locator('input[type="email"]').fill(TEST_EMAIL);
+		await page.locator('input[type="email"]').fill(email('user'));
 		await page.getByRole('button', { name: 'Send code' }).click();
 
 		// ── OTP ───────────────────────────────────────────────────────────────────
 		await expect(page).toHaveURL(/\/onboarding\/otp/);
-		const otp = await getOTP(TEST_EMAIL);
+		const otp = await getOTP(email('user'));
 		// The OTP input is a single hidden input overlaid on the digit boxes.
 		// pressSequentially fires individual input events which trigger auto-submit.
 		await page.locator('input[inputmode="numeric"]').pressSequentially(otp);
@@ -61,7 +61,7 @@ test.describe.serial('Onboarding flow', () => {
 		).toBeVisible();
 	});
 
-	test('fully onboarded user is redirected away from onboarding', async ({ page }) => {
+	test('fully onboarded user is redirected away from onboarding', async ({ page, email }) => {
 		// Run the full flow first to create the user + appUser
 		await goto(page, '/onboarding');
 		await page.getByRole('button', { name: 'Get started' }).click();
@@ -69,10 +69,10 @@ test.describe.serial('Onboarding flow', () => {
 		await page.getByRole('button', { name: 'I understand, continue' }).click();
 		await expect(page).toHaveURL(/\/onboarding\/phone/);
 		await page.getByRole('button', { name: 'Continue with email instead' }).click();
-		await page.locator('input[type="email"]').fill(TEST_EMAIL);
+		await page.locator('input[type="email"]').fill(email('user'));
 		await page.getByRole('button', { name: 'Send code' }).click();
 		await expect(page).toHaveURL(/\/onboarding\/otp/);
-		const otp = await getOTP(TEST_EMAIL);
+		const otp = await getOTP(email('user'));
 		await page.locator('input[inputmode="numeric"]').pressSequentially(otp);
 		await expect(page).toHaveURL(/\/onboarding\/verified/, { timeout: 10_000 });
 		await page.getByRole('button', { name: 'Continue' }).click();

--- a/e2e/qr-onboarding.test.ts
+++ b/e2e/qr-onboarding.test.ts
@@ -5,8 +5,6 @@ import {
 	test,
 	goto,
 	setupAuthenticatedUser,
-	SENDER_EMAIL,
-	SCANNER_EMAIL,
 	createPendingQr,
 	getAppUserId,
 	getOTP,
@@ -20,10 +18,10 @@ const SCANNER_NAME = 'QR Scanner';
 test.describe.serial('QR scan → onboarding → accept', () => {
 	let senderAppUserId: string;
 
-	test.beforeAll(async ({ browser }, testInfo) => {
+	test.beforeAll(async ({ browser, email }, testInfo) => {
 		const baseURL = testInfo.project.use.baseURL!;
 		const senderCtx = await browser.newContext({ baseURL });
-		const senderBaUserId = await setupAuthenticatedUser(senderCtx, SENDER_EMAIL, SENDER_NAME);
+		const senderBaUserId = await setupAuthenticatedUser(senderCtx, email('sender'), SENDER_NAME);
 		senderAppUserId = getAppUserId(senderBaUserId);
 		await senderCtx.close();
 	});
@@ -32,12 +30,13 @@ test.describe.serial('QR scan → onboarding → accept', () => {
 		clearOTPs();
 	});
 
-	test.afterEach(async () => {
-		await deleteTestUser(SCANNER_EMAIL);
+	test.afterEach(async ({ email }) => {
+		await deleteTestUser(email('scanner'));
 	});
 
 	test('unauthenticated scanner sees transaction info then completes fast-track onboarding', async ({
-		secondContext
+		secondContext,
+		email
 	}) => {
 		// Create a pending QR from the sender
 		const { token } = await createPendingQr(senderAppUserId, SENDER_NAME);
@@ -64,12 +63,12 @@ test.describe.serial('QR scan → onboarding → accept', () => {
 		// Switch to email for testability
 		await page.getByRole('button', { name: /continue with email/i }).click();
 		await page.waitForURL(/\/onboarding\/email/);
-		await page.locator('input[type="email"]').fill(SCANNER_EMAIL);
+		await page.locator('input[type="email"]').fill(email('scanner'));
 		await page.getByRole('button', { name: /send code/i }).click();
 
 		// OTP
 		await page.waitForURL(/\/onboarding\/otp/);
-		const otp = await getOTP(SCANNER_EMAIL);
+		const otp = await getOTP(email('scanner'));
 		await page.locator('input[inputmode="numeric"]').pressSequentially(otp);
 
 		// Verified — fast track skips the intro slides

--- a/e2e/qr-scanner.test.ts
+++ b/e2e/qr-scanner.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, chromium, type BrowserContext } from '@playwright/test';
-import { setupAuthenticatedUser, SENDER_EMAIL } from './test-utils.js';
+import { expect, chromium, type BrowserContext } from '@playwright/test';
+import { test, setupAuthenticatedUser } from './test-utils.js';
 import QRCode from 'qrcode';
 import { execSync } from 'child_process';
 import { mkdtempSync, unlinkSync, rmSync } from 'fs';
@@ -8,7 +8,6 @@ import { join } from 'path';
 
 const SENDER_NAME = 'QR Sender';
 const RECEIVER_NAME = 'QR Scanner';
-const SCANNER_EMAIL = 'e2e-qr-scanner@test.example';
 
 /**
  * Generate a .y4m fake webcam video file containing a QR code for the given URL.
@@ -40,16 +39,16 @@ test.describe.serial('QR scanner E2E', () => {
 	let senderStorage: Awaited<ReturnType<BrowserContext['storageState']>>;
 	let scannerStorage: Awaited<ReturnType<BrowserContext['storageState']>>;
 
-	test.beforeAll(async ({ browser }, testInfo) => {
+	test.beforeAll(async ({ browser, email }, testInfo) => {
 		const baseURL = testInfo.project.use.baseURL!;
 
 		const senderCtx = await browser.newContext({ baseURL });
-		await setupAuthenticatedUser(senderCtx, SENDER_EMAIL, SENDER_NAME);
+		await setupAuthenticatedUser(senderCtx, email('sender'), SENDER_NAME);
 		senderStorage = await senderCtx.storageState();
 		await senderCtx.close();
 
 		const scannerCtx = await browser.newContext({ baseURL });
-		await setupAuthenticatedUser(scannerCtx, SCANNER_EMAIL, RECEIVER_NAME);
+		await setupAuthenticatedUser(scannerCtx, email('scanner'), RECEIVER_NAME);
 		scannerStorage = await scannerCtx.storageState();
 		await scannerCtx.close();
 	});

--- a/e2e/send-receive.test.ts
+++ b/e2e/send-receive.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, type BrowserContext } from '@playwright/test';
-import { goto, setupAuthenticatedUser, SENDER_EMAIL, RECEIVER_EMAIL } from './test-utils.js';
+import { expect, type BrowserContext } from '@playwright/test';
+import { test, goto, setupAuthenticatedUser } from './test-utils.js';
 
 const SENDER_NAME = 'Test Sender';
 const RECEIVER_NAME = 'Test Receiver';
@@ -11,16 +11,16 @@ test.describe.serial('Send / Receive flow', () => {
 	// Users are created programmatically (no onboarding UI) and their session
 	// cookies are injected directly into browser contexts. Cleanup happens via
 	// globalSetup (deletes test.db) on the next Playwright run.
-	test.beforeAll(async ({ browser }, testInfo) => {
+	test.beforeAll(async ({ browser, email }, testInfo) => {
 		const baseURL = testInfo.project.use.baseURL!;
 
 		const senderCtx = await browser.newContext({ baseURL });
-		await setupAuthenticatedUser(senderCtx, SENDER_EMAIL, SENDER_NAME);
+		await setupAuthenticatedUser(senderCtx, email('sender'), SENDER_NAME);
 		senderStorage = await senderCtx.storageState();
 		await senderCtx.close();
 
 		const receiverCtx = await browser.newContext({ baseURL });
-		await setupAuthenticatedUser(receiverCtx, RECEIVER_EMAIL, RECEIVER_NAME);
+		await setupAuthenticatedUser(receiverCtx, email('receiver'), RECEIVER_NAME);
 		receiverStorage = await receiverCtx.storageState();
 		await receiverCtx.close();
 	});

--- a/e2e/share-button.test.ts
+++ b/e2e/share-button.test.ts
@@ -1,16 +1,15 @@
-import { test, expect, type BrowserContext } from '@playwright/test';
-import { goto, setupAuthenticatedUser } from './test-utils.js';
+import { expect, type BrowserContext } from '@playwright/test';
+import { test, goto, setupAuthenticatedUser } from './test-utils.js';
 
-const TEST_EMAIL = 'e2e-share-button@test.example';
 const TEST_NAME = 'Share Tester';
 
 test.describe.serial('Share button', () => {
 	let userStorage: Awaited<ReturnType<BrowserContext['storageState']>>;
 
-	test.beforeAll(async ({ browser }, testInfo) => {
+	test.beforeAll(async ({ browser, email }, testInfo) => {
 		const baseURL = testInfo.project.use.baseURL!;
 		const ctx = await browser.newContext({ baseURL });
-		await setupAuthenticatedUser(ctx, TEST_EMAIL, TEST_NAME);
+		await setupAuthenticatedUser(ctx, email('user'), TEST_NAME);
 		userStorage = await ctx.storageState();
 		await ctx.close();
 	});

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -1,9 +1,12 @@
 import type { Page, BrowserContext } from '@playwright/test';
 import { test as base } from '@playwright/test';
+import { basename } from 'path';
 import type { TestHelpers } from 'better-auth/plugins';
 import * as jose from 'jose';
 import { auth, sqlite } from './auth.js';
 import { E2E_BASE_URL, E2E_QR_JWT_SECRET } from './config.js';
+
+export { expect } from '@playwright/test';
 
 /**
  * Navigate to a URL and wait for SvelteKit hydration to complete before
@@ -19,18 +22,8 @@ export async function goto(page: Page, url: string): Promise<void> {
 	await page.locator('body.hydrated').waitFor();
 }
 
-/**
- * A stable email address used for e2e onboarding tests. Cleaned up after each
- * test via deleteTestUser().
- */
-export const TEST_EMAIL = 'e2e-onboarding@test.example';
-
-/** Stable emails for two-user send/receive flow tests. */
-export const SENDER_EMAIL = 'e2e-sender@test.example';
-export const RECEIVER_EMAIL = 'e2e-receiver@test.example';
-
-/** Stable email for the unauthenticated QR scanner in qr-onboarding tests. */
-export const SCANNER_EMAIL = 'e2e-scanner@test.example';
+// Each test file gets unique emails via the `email` fixture.
+// Do NOT add shared email exports here — they cause parallel collisions.
 
 // ── TestHelpers accessor ──────────────────────────────────────────────────────
 
@@ -142,7 +135,7 @@ export async function createTestUser(email: string, displayName: string): Promis
  * Delete the test user (and all dependent records) by email. Safe to call when
  * the user does not exist.
  */
-export async function deleteTestUser(email: string = TEST_EMAIL): Promise<void> {
+export async function deleteTestUser(email: string): Promise<void> {
 	const row = sqlite
 		.prepare<{ id: string }, [string]>(`SELECT id FROM user WHERE email = ?`)
 		.get(email);
@@ -246,8 +239,19 @@ export async function onboardUserViaEmail(
  * Custom test fixture that provides a fresh unauthenticated browser context
  * as `secondContext`. The context is automatically closed after each test,
  * eliminating the need for try/finally blocks.
+ *
+ * Also provides an `email` fixture that derives unique email addresses from the
+ * test filename, preventing parallel test collisions.
  */
-export const test = base.extend<{ secondContext: import('@playwright/test').BrowserContext }>({
+export const test = base.extend<{
+	email: (role: string) => string;
+	secondContext: import('@playwright/test').BrowserContext;
+}>({
+	// eslint-disable-next-line no-empty-pattern
+	email: async ({}: object, use, testInfo) => {
+		const prefix = basename(testInfo.file).replace(/\.test\.ts$/, '');
+		await use((role: string) => `e2e-${prefix}-${role}@test.example`);
+	},
 	secondContext: async ({ browser }, use, testInfo) => {
 		const ctx = await browser.newContext({ baseURL: testInfo.project.use.baseURL! });
 		await use(ctx);


### PR DESCRIPTION
## Summary

- Adds an `email` Playwright fixture to `e2e/test-utils.ts` that derives unique addresses from the test filename: `email('sender')` → `e2e-{filename}-sender@test.example`
- Removes shared email exports (`SENDER_EMAIL`, `RECEIVER_EMAIL`, `SCANNER_EMAIL`, `TEST_EMAIL`) that caused `setupAuthenticatedUser` collisions when test files ran in parallel against the shared SQLite database
- Migrates all 6 test files to use the fixture; updates `AGENTS.md` and `CLAUDE.md` with the new pattern

Collisions are now structurally impossible — no manual discipline required.

Closes #31 (parallel safety groundwork)

## Test plan

- [ ] `bunx playwright test` — full parallel run passes
- [ ] `bunx playwright test --workers=1` — serial baseline passes
- [ ] `bun run check && bun run lint` — clean (modulo pre-existing `barcode-detector` type error, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)