### PR TITLE
Run E2E tests against the production bun server

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,9 +15,11 @@ export default defineConfig({
 		trace: 'on-first-retry'
 	},
 	webServer: {
-		command: `rm -f ${E2E_DB_FILE} ${E2E_DB_FILE}-wal ${E2E_DB_FILE}-shm && bun run db:migrate && bun run dev -- --port 5174`,
+		command: `rm -f ${E2E_DB_FILE} ${E2E_DB_FILE}-wal ${E2E_DB_FILE}-shm && bun run db:migrate && bun run build && bun ./build/index.js`,
 		env: {
 			E2E: 'true',
+			PORT: '5174',
+			ORIGIN: E2E_BASE_URL,
 			APP_URL: E2E_BASE_URL,
 			BETTER_AUTH_URL: E2E_BASE_URL,
 			BETTER_AUTH_SECRET: E2E_AUTH_SECRET,
@@ -26,10 +28,10 @@ export default defineConfig({
 		},
 		stdout: 'pipe',
 		stderr: 'pipe',
-		timeout: 120_000,
+		timeout: 180_000,
 		gracefulShutdown: { signal: 'SIGINT', timeout: 3000 },
 		wait: {
-			stdout: /ready in/
+			stdout: /Listening/
 		}
 	},
 	projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }]


### PR DESCRIPTION
## Summary

- Switches the Playwright `webServer` from `bun run dev` to `bun run build && bun ./build/index.js`, so E2E tests exercise the same built artifact that ships to production
- Three fixes required alongside the server swap:
  - **`PORT`** env var: replaces the `--port 5174` dev-server flag
  - **`ORIGIN`** env var: overrides `svelte-adapter-bun`'s default of `https`, which was causing SvelteKit's CSRF check to reject form POSTs (`Origin: http://localhost:5174` vs reconstructed URL `https://localhost:5174`)
  - **`wait.stdout`** pattern: updated from `/ready in/` (Vite) to `/Listening/` (bun HTTP server)
- Timeout bumped 120 s → 180 s to cover the build step

## Test plan

- [x] Full suite run locally with `--workers=1` (matching CI): **36 passed, 3 skipped**
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)