### PR TITLE
Add health check endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,8 @@ ENV DB_FILE_NAME=/data/sqlite.db
 # svelte-adapter-bun reads PORT (default 3000)
 EXPOSE 3000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:3000/api/health || exit 1
+
 # Migrate then start — migrate.ts is provider-aware (SQLite or PostgreSQL)
 CMD ["sh", "-c", "bun scripts/migrate.ts && bun build/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,12 @@ services:
       - sqlite-data:/data
     ports:
       - '${PORT:-3000}:3000'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3000/api/health']
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
     restart: unless-stopped
 
   # ── PostgreSQL deployment ────────────────────────────────────────────────────
@@ -39,6 +45,12 @@ services:
         condition: service_healthy
     ports:
       - '${PORT:-3000}:3000'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3000/api/health']
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
     restart: unless-stopped
 
   postgres:

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,0 +1,17 @@
+import { json } from '@sveltejs/kit';
+import { sql } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import { config } from '$lib/config';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+	try {
+		await db.run(sql`SELECT 1`);
+		return json({ status: 'ok', db: 'ok', dbProvider: config.dbProvider });
+	} catch (err) {
+		return json(
+			{ status: 'error', db: 'error', error: err instanceof Error ? err.message : 'Unknown' },
+			{ status: 503 }
+		);
+	}
+};


### PR DESCRIPTION
## Summary

- Adds `GET /api/health` — pings the DB with `SELECT 1` via Drizzle (works for both SQLite and PostgreSQL), returns `{ status, db, dbProvider }` (200) or 503 on failure. No auth required.
- Adds `HEALTHCHECK` directive to the Dockerfile (`wget` since Alpine doesn't ship `curl`)
- Adds `healthcheck` config to both `app-sqlite` and `app-postgres` services in `docker-compose.yml` (30s interval, 10s start period)

## Test plan

- [ ] `bun run dev` → `curl http://localhost:5173/api/health` returns `{"status":"ok","db":"ok","dbProvider":"sqlite"}`
- [ ] `docker compose --profile sqlite up --build` → `docker inspect` shows container status as `healthy`
- [ ] With DB unavailable: endpoint returns 503

🤖 Generated with [Claude Code](https://claude.ai/claude-code)