### PR TITLE
Fix health endpoint for PostgreSQL

### DIFF
--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,12 +1,12 @@
 import { json } from '@sveltejs/kit';
-import { sql } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { config } from '$lib/config';
+import { user } from '$lib/server/schema';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async () => {
 	try {
-		await db.run(sql`SELECT 1`);
+		await db.select().from(user).limit(1);
 		return json({ status: 'ok', db: 'ok', dbProvider: config.dbProvider });
 	} catch (err) {
 		return json(


### PR DESCRIPTION
## Summary

Fixes a bug introduced in #43 where `GET /api/health` always returned 503 under `DB_PROVIDER=pg`.

`db.run()` is a SQLite-specific method on `BunSQLiteDatabase`. The `db` export is cast to that type for static analysis, but at runtime under PostgreSQL it is a `BunSQLDatabase` instance (from `drizzle-orm/bun-sql`) which has no `.run()` method. The call threw a `TypeError`, caught by the try/catch, returning 503 — breaking the Docker healthcheck on `app-postgres`.

The fix replaces the raw SQL call with the Drizzle query builder (`db.select().from(user).limit(1)`), which is implemented on both drivers.

## Test plan

- [ ] `bun run dev` → `curl http://localhost:5173/api/health` still returns 200 with `{"status":"ok","db":"ok","dbProvider":"sqlite"}`
- [ ] With `DB_PROVIDER=pg`: same endpoint returns 200 (not 503)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)