### PR TITLE
feat: include amount, note, and app name in copy/share text

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -158,6 +158,8 @@
 	"qr_copy_link": "Copy link",
 	"qr_copied": "Copied!",
 	"qr_share": "Share",
+	"qr_share_text": "{amount} of credit through {appName}.",
+	"qr_share_text_with_note": "{amount} of credit through {appName} — {note}",
 
 	"locale_name": "English",
 

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -158,6 +158,8 @@
 	"qr_copy_link": "Link kopiëren",
 	"qr_copied": "Gekopieerd!",
 	"qr_share": "Delen",
+	"qr_share_text": "{amount} aan krediet via {appName}.",
+	"qr_share_text_with_note": "{amount} aan krediet via {appName} — {note}",
 
 	"locale_name": "Nederlands",
 

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -158,6 +158,8 @@
 	"qr_copy_link": "Copiar link",
 	"qr_copied": "Copiado!",
 	"qr_share": "Partilhar",
+	"qr_share_text": "{amount} de crédito através do {appName}.",
+	"qr_share_text_with_note": "{amount} de crédito através do {appName} — {note}",
 
 	"locale_name": "Português",
 

--- a/src/routes/(app)/receive/+page.server.ts
+++ b/src/routes/(app)/receive/+page.server.ts
@@ -10,6 +10,7 @@ import type { PageServerLoad, Actions } from './$types';
 
 export const load: PageServerLoad = async () => {
 	return {
+		appName: process.env.PUBLIC_APP_NAME || 'Mutuvia',
 		unitSymbol: process.env.PUBLIC_UNIT_SYMBOL || '€',
 		decimalPlaces: parseInt(process.env.UNIT_DECIMAL_PLACES || '2', 10),
 		qrTtlSeconds: parseInt(process.env.QR_TTL_SECONDS || '600', 10)

--- a/src/routes/(app)/receive/+page.svelte
+++ b/src/routes/(app)/receive/+page.svelte
@@ -30,6 +30,19 @@
 	let completedAmount = $state('');
 	let qrUrl = $state('');
 	let canShare = $derived(browser && typeof navigator.share === 'function');
+	let formattedAmount = $derived(
+		`${data.unitSymbol}\u00A0${parseFloat(amount || '0').toFixed(data.decimalPlaces)}`
+	);
+	let shareDescription = $derived(
+		note.trim()
+			? m.qr_share_text_with_note({
+					amount: formattedAmount,
+					appName: data.appName,
+					note: note.trim()
+				})
+			: m.qr_share_text({ amount: formattedAmount, appName: data.appName })
+	);
+	let copyText = $derived(`${shareDescription}\n${qrUrl}`);
 
 	$effect(() => {
 		if (form?.qrUrl) {
@@ -47,7 +60,7 @@
 	}
 
 	function shareLink() {
-		navigator.share({ url: qrUrl });
+		navigator.share({ text: shareDescription, url: qrUrl });
 	}
 
 	function startCountdown(expires: string) {
@@ -168,7 +181,7 @@
 				{#if qrUrl}
 					<p class="mb-2 max-w-[280px] truncate text-xs text-muted-foreground">{qrUrl}</p>
 					<div class="mb-4 flex gap-2">
-						<CopyButton text={qrUrl} variant="outline" class="flex-1 rounded-xl text-sm">
+						<CopyButton text={copyText} variant="outline" class="flex-1 rounded-xl text-sm">
 							{m.qr_copy_link()}
 						</CopyButton>
 						{#if canShare}

--- a/src/routes/(app)/send/+page.server.ts
+++ b/src/routes/(app)/send/+page.server.ts
@@ -14,6 +14,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 	return {
 		needsConsent,
+		appName: process.env.PUBLIC_APP_NAME || 'Mutuvia',
 		unitSymbol: process.env.PUBLIC_UNIT_SYMBOL || '€',
 		decimalPlaces: parseInt(process.env.UNIT_DECIMAL_PLACES || '2', 10),
 		qrTtlSeconds: parseInt(process.env.QR_TTL_SECONDS || '600', 10)

--- a/src/routes/(app)/send/+page.svelte
+++ b/src/routes/(app)/send/+page.svelte
@@ -30,6 +30,19 @@
 	let completedAmount = $state('');
 	let qrUrl = $state('');
 	let canShare = $derived(browser && typeof navigator.share === 'function');
+	let formattedAmount = $derived(
+		`${data.unitSymbol}\u00A0${parseFloat(amount || '0').toFixed(data.decimalPlaces)}`
+	);
+	let shareDescription = $derived(
+		note.trim()
+			? m.qr_share_text_with_note({
+					amount: formattedAmount,
+					appName: data.appName,
+					note: note.trim()
+				})
+			: m.qr_share_text({ amount: formattedAmount, appName: data.appName })
+	);
+	let copyText = $derived(`${shareDescription}\n${qrUrl}`);
 
 	$effect(() => {
 		if (form?.consented) {
@@ -50,7 +63,7 @@
 	}
 
 	function shareLink() {
-		navigator.share({ url: qrUrl });
+		navigator.share({ text: shareDescription, url: qrUrl });
 	}
 
 	function startCountdown(expires: string) {
@@ -196,7 +209,7 @@
 				{#if qrUrl}
 					<p class="mb-2 max-w-[280px] truncate text-xs text-muted-foreground">{qrUrl}</p>
 					<div class="mb-4 flex gap-2">
-						<CopyButton text={qrUrl} variant="outline" class="flex-1 rounded-xl text-sm">
+						<CopyButton text={copyText} variant="outline" class="flex-1 rounded-xl text-sm">
 							{m.qr_copy_link()}
 						</CopyButton>
 						{#if canShare}


### PR DESCRIPTION
Closes #50

## Summary

- Copy and share now include a meaningful message alongside the URL: `{amount} of credit through {appName}.` (or with note: `{amount} of credit through {appName} — {note}`)
- `navigator.share()` passes the description as `text` and the URL separately, letting the OS combine them naturally
- `CopyButton` copies the full message + URL so it can be pasted directly into a chat
- Added `appName` to load data on both send and receive server pages
- Added `qr_share_text` / `qr_share_text_with_note` i18n keys in EN, PT, and NL

## Test plan

- [ ] On `/send`: enter amount and note, generate QR, tap Copy — clipboard should contain the description + newline + URL
- [ ] On `/send`: same without note — description omits the note part
- [ ] On `/send`: tap Share (on mobile) — native share sheet should show the description as text and URL separately
- [ ] Repeat all above on `/receive`
- [ ] `bun run check` passes
- [ ] `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)