### PR TITLE
Add OG/Twitter Card meta tags to accept page (#51)

### DIFF
--- a/e2e/og-preview.test.ts
+++ b/e2e/og-preview.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as jose from 'jose';
+import {
+	test,
+	expect,
+	goto,
+	setupAuthenticatedUser,
+	createPendingQr,
+	getAppUserId
+} from './test-utils.js';
+import { sqlite } from './auth.js';
+import { E2E_QR_JWT_SECRET, E2E_BASE_URL } from './config.js';
+
+const INITIATOR_NAME = 'OG Initiator';
+
+/**
+ * Insert a pending QR row with direction='receive' and sign a JWT for it.
+ * Mirrors createPendingQr from test-utils but allows configuring direction and amount.
+ */
+async function createReceiveQr(
+	initiatingAppUserId: string,
+	initiatorName: string,
+	amountCents: number
+): Promise<{ token: string; qrId: string }> {
+	const qrId = crypto.randomUUID();
+	const now = Math.floor(Date.now() / 1000);
+
+	sqlite
+		.prepare(
+			`INSERT INTO pending_qr (id, initiating_user_id, direction, amount, status, created_at, expires_at)
+			 VALUES (?, ?, 'receive', ?, 'pending', ?, ?)`
+		)
+		.run(qrId, initiatingAppUserId, amountCents, now, now + 600);
+
+	const secret = new TextEncoder().encode(E2E_QR_JWT_SECRET);
+	const token = await new jose.SignJWT({ amt: amountCents, dir: 'receive', dn: initiatorName })
+		.setProtectedHeader({ alg: 'HS256' })
+		.setJti(qrId)
+		.setIssuer(E2E_BASE_URL)
+		.setIssuedAt()
+		.setExpirationTime('600s')
+		.sign(secret);
+
+	return { token, qrId };
+}
+
+test.describe('OG meta tags on /accept/[token]', () => {
+	let initiatorAppUserId: string;
+
+	test.beforeAll(async ({ browser, email }, testInfo) => {
+		const baseURL = testInfo.project.use.baseURL!;
+		const ctx = await browser.newContext({ baseURL });
+		const initiatorBaUserId = await setupAuthenticatedUser(ctx, email('initiator'), INITIATOR_NAME);
+		initiatorAppUserId = getAppUserId(initiatorBaUserId);
+		await ctx.close();
+	});
+
+	test('send direction: OG tags contain payment amount and correct metadata', async ({
+		secondContext
+	}) => {
+		const { token } = await createPendingQr(initiatorAppUserId, INITIATOR_NAME);
+		const page = await secondContext.newPage();
+
+		await goto(page, `/accept/${token}`);
+
+		// Page title
+		await expect(page).toHaveTitle(/Payment of/);
+		await expect(page).toHaveTitle(/5\.00/);
+
+		// og:title
+		const ogTitle = page.locator('meta[property="og:title"]');
+		await expect(ogTitle).toHaveAttribute('content', /Payment of/);
+		await expect(ogTitle).toHaveAttribute('content', /5\.00/);
+
+		// og:description
+		const ogDescription = page.locator('meta[property="og:description"]');
+		await expect(ogDescription).toHaveAttribute('content', 'Mutual credit for your community');
+
+		// og:site_name
+		const ogSiteName = page.locator('meta[property="og:site_name"]');
+		await expect(ogSiteName).toHaveAttribute('content', 'Mutuvia');
+
+		// og:type
+		const ogType = page.locator('meta[property="og:type"]');
+		await expect(ogType).toHaveAttribute('content', 'website');
+
+		// og:url
+		const ogUrl = page.locator('meta[property="og:url"]');
+		await expect(ogUrl).toHaveAttribute('content', /\/accept\//);
+
+		// twitter:card
+		const twitterCard = page.locator('meta[name="twitter:card"]');
+		await expect(twitterCard).toHaveAttribute('content', 'summary');
+
+		// twitter:title
+		const twitterTitle = page.locator('meta[name="twitter:title"]');
+		await expect(twitterTitle).toHaveAttribute('content', /Payment of/);
+
+		// twitter:description
+		const twitterDescription = page.locator('meta[name="twitter:description"]');
+		await expect(twitterDescription).toHaveAttribute('content', 'Mutual credit for your community');
+
+		// Privacy: initiator's display name must NOT appear in og:title or og:description
+		const ogTitleContent = await ogTitle.getAttribute('content');
+		const ogDescriptionContent = await ogDescription.getAttribute('content');
+		expect(ogTitleContent).not.toContain(INITIATOR_NAME);
+		expect(ogDescriptionContent).not.toContain(INITIATOR_NAME);
+	});
+
+	test('receive direction: OG tags contain request amount', async ({ secondContext }) => {
+		const { token } = await createReceiveQr(initiatorAppUserId, INITIATOR_NAME, 750);
+		const page = await secondContext.newPage();
+
+		await goto(page, `/accept/${token}`);
+
+		// og:title should reflect "Request for" phrasing
+		const ogTitle = page.locator('meta[property="og:title"]');
+		await expect(ogTitle).toHaveAttribute('content', /Request for/);
+		await expect(ogTitle).toHaveAttribute('content', /7\.50/);
+
+		// og:description unchanged
+		const ogDescription = page.locator('meta[property="og:description"]');
+		await expect(ogDescription).toHaveAttribute('content', 'Mutual credit for your community');
+	});
+
+	test('expired / invalid token: OG tags show "Link expired"', async ({ secondContext }) => {
+		const page = await secondContext.newPage();
+
+		await goto(page, '/accept/invalid-token-that-will-fail-verification');
+
+		// og:title must be exactly "Link expired"
+		const ogTitle = page.locator('meta[property="og:title"]');
+		await expect(ogTitle).toHaveAttribute('content', 'Link expired');
+
+		// og:description still present
+		const ogDescription = page.locator('meta[property="og:description"]');
+		await expect(ogDescription).toHaveAttribute('content', 'Mutual credit for your community');
+	});
+});
+// Initiator user is intentionally not cleaned up — global setup deletes test.db on the next run.

--- a/messages/de.json
+++ b/messages/de.json
@@ -195,5 +195,10 @@
 	"about_with_ai": "mit Claude (dem KI-Assistenten von Anthropic) als Programmierkollaborateur",
 	"about_open_source": "Lizenziert unter AGPL-3.0",
 
-	"how_it_works_back_home": "Zurück zur Startseite"
+	"how_it_works_back_home": "Zurück zur Startseite",
+
+	"og_send_title": "Zahlung von {amount}",
+	"og_receive_title": "Anforderung von {amount}",
+	"og_description": "Gegenseitiger Kredit für deine Gemeinschaft",
+	"og_expired_title": "Link abgelaufen"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -214,5 +214,10 @@
 
 	"faq_q_question_not_answered": "My question is not answered here.",
 	"faq_a_question_not_answered": "We would love to hear from you. You can ask a question, report a bug, or suggest a feature on GitHub.",
-	"faq_link_report_issue": "Open an issue or discussion on GitHub"
+	"faq_link_report_issue": "Open an issue or discussion on GitHub",
+
+	"og_send_title": "Payment of {amount}",
+	"og_receive_title": "Request for {amount}",
+	"og_description": "Mutual credit for your community",
+	"og_expired_title": "Link expired"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -214,5 +214,10 @@
 
 	"faq_q_question_not_answered": "Mijn vraag staat er niet bij.",
 	"faq_a_question_not_answered": "We horen graag van je. Je kunt een vraag stellen, een bug melden of een functie voorstellen op GitHub.",
-	"faq_link_report_issue": "Open een issue of discussie op GitHub"
+	"faq_link_report_issue": "Open een issue of discussie op GitHub",
+
+	"og_send_title": "Betaling van {amount}",
+	"og_receive_title": "Verzoek voor {amount}",
+	"og_description": "Wederzijds krediet voor jouw gemeenschap",
+	"og_expired_title": "Link verlopen"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -214,5 +214,10 @@
 
 	"faq_q_question_not_answered": "A minha pergunta não está aqui.",
 	"faq_a_question_not_answered": "Adoraríamos ouvir-te. Podes fazer uma pergunta, reportar um erro ou sugerir uma funcionalidade no GitHub.",
-	"faq_link_report_issue": "Abrir um assunto ou discussão no GitHub"
+	"faq_link_report_issue": "Abrir um assunto ou discussão no GitHub",
+
+	"og_send_title": "Pagamento de {amount}",
+	"og_receive_title": "Pedido de {amount}",
+	"og_description": "Crédito mútuo para a tua comunidade",
+	"og_expired_title": "Link expirado"
 }

--- a/src/routes/accept/[token]/+page.svelte
+++ b/src/routes/accept/[token]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { enhance } from '$app/forms';
+	import { page } from '$app/state';
+	import { env } from '$env/dynamic/public';
 	import { Button } from '$lib/components/ui/button';
 	import { Card } from '$lib/components/ui/card';
 	import CheckIcon from '@lucide/svelte/icons/check';
@@ -8,7 +10,30 @@
 	import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
 
 	let { data, form } = $props();
+
+	const appName = env.PUBLIC_APP_NAME || 'Mutuvia';
+
+	const ogTitle = $derived(
+		data.expired
+			? m.og_expired_title()
+			: data.direction === 'send'
+				? m.og_send_title({ amount: data.formattedAmount ?? '' })
+				: m.og_receive_title({ amount: data.formattedAmount ?? '' })
+	);
+	const ogDescription = $derived(m.og_description());
 </script>
+
+<svelte:head>
+	<title>{ogTitle} — {appName}</title>
+	<meta property="og:title" content={ogTitle} />
+	<meta property="og:description" content={ogDescription} />
+	<meta property="og:site_name" content={appName} />
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content={page.url.href} />
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:title" content={ogTitle} />
+	<meta name="twitter:description" content={ogDescription} />
+</svelte:head>
 
 {#snippet transactionSummary()}
 	<h1 class="mb-4 font-serif text-2xl font-semibold">


### PR DESCRIPTION
## Summary

- Adds `<svelte:head>` to `/accept/[token]` with full OG + Twitter Card meta tags, rendered server-side so link unfurlers (Signal, Telegram, WhatsApp, etc.) see them
- Titles are direction-aware: "Payment of €X.XX" (send), "Request for €X.XX" (receive), "Link expired" (invalid/expired token)
- Generic description: "Mutual credit for your community"
- Privacy-safe: no initiator name or note appears in any meta tag
- New i18n keys (`og_send_title`, `og_receive_title`, `og_description`, `og_expired_title`) added to all 4 locales (en, pt, nl, de)

## Test plan

- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean
- [x] E2E tests in `e2e/og-preview.test.ts` — 3 tests pass (send direction, receive direction, expired/invalid token)
- [x] Privacy assertion: initiator name absent from `og:title` and `og:description`

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)