### PR TITLE
Fix Sentry client not initializing in Docker builds

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import * as Sentry from '@sentry/sveltekit';
+import { env } from '$env/dynamic/public';
 
-const dsn = import.meta.env.PUBLIC_SENTRY_DSN;
+const dsn = env.PUBLIC_SENTRY_DSN;
 
 if (dsn) {
 	Sentry.init({


### PR DESCRIPTION
## Summary

- `import.meta.env.PUBLIC_SENTRY_DSN` is statically replaced at Vite build time, but `PUBLIC_SENTRY_DSN` is never passed as a Docker build arg — so the client bundle always gets `undefined`, `Sentry.init()` never runs, and the feedback widget (and all client-side Sentry) is silently disabled
- Server-side logging worked because `instrumentation.server.ts` uses `process.env` (runtime)
- Switches `hooks.client.ts` to `$env/dynamic/public`, which reads runtime values serialized into the HTML by SvelteKit — consistent with how `sentry-tunnel/+server.ts` already accesses the same variable

Fixes #48

## Test plan

- [ ] `bun run check` passes (verified ✓)
- [ ] Run dev with `PUBLIC_SENTRY_DSN` set in `.env` — feedback button appears bottom-right
- [ ] Run dev without `PUBLIC_SENTRY_DSN` — no button, no errors
- [ ] Docker build without `PUBLIC_SENTRY_DSN` build arg + run with it as a runtime env var — feedback button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)