### PR TITLE
Fix: wrong OTP code falsely verifies user, OTP input not auto-focused

### DIFF
--- a/e2e/otp-error.test.ts
+++ b/e2e/otp-error.test.ts
@@ -1,0 +1,59 @@
+import type { Page } from '@playwright/test';
+import { test, expect, goto, getOTP, clearOTPs, deleteTestUser } from './test-utils.js';
+
+async function navigateToOtpPage(page: Page, userEmail: string) {
+	// ── Welcome ───────────────────────────────────────────────────────────────
+	await goto(page, '/onboarding');
+	await page.getByRole('button', { name: 'Get started' }).click();
+
+	// ── Consent ───────────────────────────────────────────────────────────────
+	await page.waitForURL(/\/onboarding\/consent/);
+	await page.getByRole('button', { name: 'I understand, continue' }).click();
+
+	// ── Phone (pivot to email) ────────────────────────────────────────────────
+	await page.waitForURL(/\/onboarding\/phone/);
+	await page.getByRole('button', { name: 'Continue with email instead' }).click();
+
+	// ── Email ─────────────────────────────────────────────────────────────────
+	await page.waitForURL(/\/onboarding\/email/);
+	await page.locator('input[type="email"]').fill(userEmail);
+	await page.getByRole('button', { name: 'Send code' }).click();
+
+	// ── OTP ───────────────────────────────────────────────────────────────────
+	await page.waitForURL(/\/onboarding\/otp/);
+}
+
+test.describe.serial('OTP error handling', () => {
+	test.afterEach(async ({ email }) => {
+		await deleteTestUser(email('user'));
+		clearOTPs();
+	});
+
+	test('wrong OTP shows error and stays on OTP page', async ({ page, email }) => {
+		await navigateToOtpPage(page, email('user'));
+
+		await page.locator('input[inputmode="numeric"]').pressSequentially('000000');
+
+		await expect(page.locator('.text-red-600')).toBeVisible({ timeout: 10_000 });
+		await expect(page).toHaveURL(/\/onboarding\/otp/);
+		await expect(page.locator('input[inputmode="numeric"]')).toHaveValue('');
+	});
+
+	test('correct OTP after failed attempt succeeds', async ({ page, email }) => {
+		await navigateToOtpPage(page, email('user'));
+
+		const otp = await getOTP(email('user'));
+
+		await page.locator('input[inputmode="numeric"]').pressSequentially('000000');
+		await expect(page.locator('.text-red-600')).toBeVisible({ timeout: 10_000 });
+
+		await page.locator('input[inputmode="numeric"]').pressSequentially(otp);
+		await expect(page).toHaveURL(/\/onboarding\/verified/, { timeout: 10_000 });
+	});
+
+	test('OTP input is auto-focused on page load', async ({ page, email }) => {
+		await navigateToOtpPage(page, email('user'));
+
+		await expect(page.locator('input[inputmode="numeric"]')).toBeFocused();
+	});
+});

--- a/messages/en.json
+++ b/messages/en.json
@@ -46,6 +46,7 @@
 	"otp_countdown": "{seconds}s",
 	"otp_cta": "Verify",
 	"otp_back": "Back",
+	"otp_invalid_code": "Invalid code. Please try again.",
 
 	"verified_title": "You're verified",
 	"verified_body": "Your number is confirmed. Let's get you set up.",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -46,6 +46,7 @@
 	"otp_countdown": "{seconds}s",
 	"otp_cta": "Verifiëren",
 	"otp_back": "Terug",
+	"otp_invalid_code": "Ongeldige code. Probeer het opnieuw.",
 
 	"verified_title": "Geverifieerd",
 	"verified_body": "Je nummer is bevestigd. Laten we alles instellen.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -46,6 +46,7 @@
 	"otp_countdown": "{seconds}s",
 	"otp_cta": "Verificar",
 	"otp_back": "Voltar",
+	"otp_invalid_code": "Código inválido. Tente novamente.",
 
 	"verified_title": "Verificado",
 	"verified_body": "O teu número está confirmado. Vamos configurar tudo.",

--- a/src/routes/onboarding/email/+page.svelte
+++ b/src/routes/onboarding/email/+page.svelte
@@ -14,13 +14,15 @@
 	async function sendEmailOtp() {
 		isLoading = true;
 		authError = '';
-		try {
-			await authClient.emailOtp.sendVerificationOtp({ email: emailAddress, type: 'sign-in' });
+		const { error } = await authClient.emailOtp.sendVerificationOtp({
+			email: emailAddress,
+			type: 'sign-in'
+		});
+		isLoading = false;
+		if (error) {
+			authError = error.message || m.error_send_code();
+		} else {
 			goto(`/onboarding/otp?dest=${encodeURIComponent(emailAddress)}&method=email`);
-		} catch (e: unknown) {
-			authError = e instanceof Error ? e.message : m.error_send_code();
-		} finally {
-			isLoading = false;
 		}
 	}
 </script>

--- a/src/routes/onboarding/otp/+page.svelte
+++ b/src/routes/onboarding/otp/+page.svelte
@@ -12,6 +12,11 @@
 	let isLoading = $state(false);
 	let authError = $state('');
 	let countdown = $state(30);
+	let otpInput = $state<HTMLInputElement | undefined>(undefined);
+
+	$effect(() => {
+		otpInput?.focus();
+	});
 
 	$effect(() => {
 		const interval = setInterval(() => {
@@ -23,32 +28,40 @@
 	async function verifyOtp() {
 		isLoading = true;
 		authError = '';
-		try {
-			if (data.otpMethod === 'phone') {
-				await authClient.phoneNumber.verify({ phoneNumber: data.otpDestination, code: otpCode });
-			} else {
-				await authClient.signIn.emailOtp({ email: data.otpDestination, otp: otpCode });
-			}
+		const result =
+			data.otpMethod === 'phone'
+				? await authClient.phoneNumber.verify({
+						phoneNumber: data.otpDestination,
+						code: otpCode
+					})
+				: await authClient.signIn.emailOtp({ email: data.otpDestination, otp: otpCode });
+		isLoading = false;
+		if (result.error) {
+			authError = result.error.message || m.otp_invalid_code();
+			otpCode = '';
+			otpInput?.focus();
+		} else {
 			goto('/onboarding/verified', { invalidateAll: true });
-		} catch (e: unknown) {
-			authError = e instanceof Error ? e.message : 'Invalid code';
-		} finally {
-			isLoading = false;
 		}
 	}
 
 	async function resendOtp() {
 		if (countdown > 0) return;
-		if (data.otpMethod === 'phone') {
-			await authClient.phoneNumber.sendOtp({ phoneNumber: data.otpDestination });
-		} else {
-			await authClient.emailOtp.sendVerificationOtp({
-				email: data.otpDestination,
-				type: 'sign-in'
-			});
+		const result =
+			data.otpMethod === 'phone'
+				? await authClient.phoneNumber.sendOtp({ phoneNumber: data.otpDestination })
+				: await authClient.emailOtp.sendVerificationOtp({
+						email: data.otpDestination,
+						type: 'sign-in'
+					});
+		if (result.error) {
+			authError = result.error.message || m.error_send_code();
+			return;
 		}
 		otpCode = '';
+		authError = '';
 		countdown = 30;
+		otpInput?.focus();
 	}
 
 	function handleOtpInput(e: Event) {
@@ -82,6 +95,7 @@
 	<!-- OTP input -->
 	<div class="relative mx-auto mb-6 flex justify-center gap-2.5">
 		<input
+			bind:this={otpInput}
 			type="text"
 			inputmode="numeric"
 			autocomplete="one-time-code"

--- a/src/routes/onboarding/phone/+page.svelte
+++ b/src/routes/onboarding/phone/+page.svelte
@@ -18,13 +18,12 @@
 		if (!phoneValue) return;
 		isLoading = true;
 		authError = '';
-		try {
-			await authClient.phoneNumber.sendOtp({ phoneNumber: phoneValue });
+		const { error } = await authClient.phoneNumber.sendOtp({ phoneNumber: phoneValue });
+		isLoading = false;
+		if (error) {
+			authError = error.message || m.error_send_code();
+		} else {
 			goto(`/onboarding/otp?dest=${encodeURIComponent(phoneValue)}&method=phone`);
-		} catch (e: unknown) {
-			authError = e instanceof Error ? e.message : m.error_send_code();
-		} finally {
-			isLoading = false;
 		}
 	}
 </script>


### PR DESCRIPTION
Fixes #47.

## Summary

- **Wrong OTP still verified**: better-auth client methods return `{ data, error }` instead of throwing. All three onboarding pages used `try/catch` which never caught anything, so failed verification silently fell through to `goto('/onboarding/verified')`. Switched to destructuring the return value and checking `error` before navigating.
- **OTP input not auto-focused**: Added `bind:this` ref + `$effect` to focus the hidden numeric input on mount.
- **On wrong code**: clears the input and re-focuses it so the user can retry immediately.
- **resendOtp()**: fixed — had zero error handling before.

## Test plan

- [x] `bun run check` — passes (0 errors)
- [x] `bun run lint` — passes (pre-existing `project.inlang/` warning unrelated)
- [x] New E2E tests in `e2e/otp-error.test.ts`:
  - wrong OTP shows error message and stays on OTP page, input cleared
  - correct OTP after a failed attempt successfully navigates to `/onboarding/verified`
  - OTP input is auto-focused on page load
- [x] All 42 E2E tests pass (3 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)