### PR TITLE
fix: preserve amount/note in share text after QR generation (closes #56)

### DIFF
--- a/src/routes/(app)/receive/+page.svelte
+++ b/src/routes/(app)/receive/+page.svelte
@@ -110,7 +110,13 @@
 		<h1 class="mb-4 font-serif text-2xl font-semibold">{m.home_receive()}</h1>
 		<p class="mb-4 text-sm text-muted-foreground">{m.receive_helper()}</p>
 
-		<form method="POST" action="?/createQr" use:enhance>
+		<form
+			method="POST"
+			action="?/createQr"
+			use:enhance={() =>
+				async ({ update }) =>
+					update({ reset: false })}
+		>
 			<Label class="mb-2 text-sm text-muted-foreground">{m.send_amount_label()}</Label>
 			<div class="mb-4 flex items-center gap-2">
 				<span class="text-2xl font-medium text-muted-foreground">{data.unitSymbol}</span>

--- a/src/routes/(app)/receive/page.svelte.test.ts
+++ b/src/routes/(app)/receive/page.svelte.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Regression test for issue #56: share/copy text shows wrong amount after QR generation.
+// Root cause: use:enhance default behavior resets the form on success, clearing bound amount/note state.
+// Fix: pass { reset: false } to update() in the enhance callback.
+
+import { vi, describe, test, expect, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import ReceivePage from './+page.svelte';
+
+vi.mock('$app/forms', () => ({
+	enhance: vi.fn().mockReturnValue({ destroy: vi.fn() })
+}));
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+vi.mock('$app/environment', () => ({ browser: false }));
+vi.mock('qrcode', () => ({
+	default: { toDataURL: vi.fn().mockResolvedValue('data:image/png;base64,test') }
+}));
+vi.mock('$lib/paraglide/messages.js', () => ({
+	home_receive: () => 'Receive',
+	receive_helper: () => 'Ask someone to scan this code.',
+	send_amount_label: () => 'Amount',
+	receive_note_placeholder: () => 'Add a note',
+	receive_cta: () => 'Generate QR',
+	consent_back: () => 'Back',
+	qr_share_text: ({ amount, appName }: { amount: string; appName: string }) =>
+		`${amount} of credit through ${appName}.`,
+	qr_share_text_with_note: ({
+		amount,
+		note,
+		appName
+	}: {
+		amount: string;
+		note: string;
+		appName: string;
+	}) => `${amount} for "${note}" through ${appName}.`,
+	qr_copy_link: () => 'Copy link',
+	qr_share: () => 'Share',
+	receive_qr_caption: () => 'Scan to pay',
+	send_qr_expired: () => 'Expired',
+	send_cancel: () => 'Cancel',
+	receive_back_home: () => 'Back home',
+	receive_declined: () => 'Declined',
+	receive_done: () => 'Done'
+}));
+
+const mockData = {
+	unitSymbol: '€',
+	decimalPlaces: 2,
+	appName: 'Mutuvia',
+	qrTtlSeconds: 600
+};
+
+describe('receive page – issue #56: share text amount', () => {
+	let enhanceMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		const formsModule = await import('$app/forms');
+		enhanceMock = vi.mocked(formsModule.enhance);
+		enhanceMock.mockClear();
+		enhanceMock.mockReturnValue({ destroy: vi.fn() });
+	});
+
+	test('amount is preserved after createQr form submission (regression: issue #56)', async () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const { getByRole } = render(ReceivePage, { props: { data: mockData as any, form: null } });
+
+		// Fill in the amount
+		const amountInput = getByRole('spinbutton'); // type="number"
+		await fireEvent.input(amountInput, { target: { value: '50' } });
+		expect(amountInput).toHaveValue(50); // sanity check
+
+		// The enhance action should have been registered for the createQr form
+		expect(enhanceMock).toHaveBeenCalled();
+		const [formElement, submitCallback] = enhanceMock.mock.calls[0] as [
+			HTMLFormElement,
+			((...args: unknown[]) => unknown) | undefined
+		];
+
+		// Simulate SvelteKit's use:enhance lifecycle on a successful action.
+		// By default (no `{ reset: false }`), SvelteKit calls form.reset() after update().
+		// The fix supplies a callback that passes `{ reset: false }` to prevent this.
+		const updateMock = vi.fn().mockImplementation(async (opts?: { reset?: boolean }) => {
+			if (opts?.reset !== false) {
+				// Default SvelteKit behavior: reset the form, clearing bound inputs
+				formElement.reset();
+			}
+		});
+
+		if (submitCallback) {
+			// Component provides a custom enhance callback — invoke the full chain
+			const innerHandler = submitCallback({
+				action: new URL('http://localhost/?/createQr'),
+				formData: new FormData(),
+				formElement,
+				controller: new AbortController(),
+				submitter: null,
+				cancel: vi.fn()
+			});
+			if (innerHandler && typeof innerHandler === 'function') {
+				await (innerHandler as (opts: unknown) => Promise<void>)({
+					update: updateMock,
+					formData: new FormData(),
+					formElement,
+					action: new URL('http://localhost/?/createQr'),
+					result: { type: 'success', status: 200, data: {} },
+					applyAction: vi.fn()
+				});
+			}
+		} else {
+			// No custom callback: default use:enhance resets the form on success
+			formElement.reset();
+		}
+
+		// After form submission, the amount should still reflect what the user entered.
+		// Without the fix, the form reset clears the bound `amount` state → 0.
+		expect(amountInput).toHaveValue(50);
+	});
+});

--- a/src/routes/(app)/send/+page.svelte
+++ b/src/routes/(app)/send/+page.svelte
@@ -137,7 +137,13 @@
 	{#if step === 'amount'}
 		<h1 class="mb-4 font-serif text-2xl font-semibold">{m.home_send()}</h1>
 
-		<form method="POST" action="?/createQr" use:enhance>
+		<form
+			method="POST"
+			action="?/createQr"
+			use:enhance={() =>
+				async ({ update }) =>
+					update({ reset: false })}
+		>
 			<Label class="mb-2 text-sm text-muted-foreground">{m.send_amount_label()}</Label>
 			<div class="mb-4 flex items-center gap-2">
 				<span class="text-2xl font-medium text-muted-foreground">{data.unitSymbol}</span>

--- a/src/routes/(app)/send/page.svelte.test.ts
+++ b/src/routes/(app)/send/page.svelte.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Regression test for issue #56: share/copy text shows wrong amount after QR generation.
+// Root cause: use:enhance default behavior resets the form on success, clearing bound amount/note state.
+// Fix: pass { reset: false } to update() in the enhance callback.
+
+import { vi, describe, test, expect, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import SendPage from './+page.svelte';
+
+vi.mock('$app/forms', () => ({
+	enhance: vi.fn().mockReturnValue({ destroy: vi.fn() })
+}));
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+vi.mock('$app/environment', () => ({ browser: false }));
+vi.mock('qrcode', () => ({
+	default: { toDataURL: vi.fn().mockResolvedValue('data:image/png;base64,test') }
+}));
+vi.mock('$lib/paraglide/messages.js', () => ({
+	home_send: () => 'Send',
+	send_amount_label: () => 'Amount',
+	send_note_placeholder: () => 'Add a note',
+	send_cta: () => 'Generate QR',
+	consent_back: () => 'Back',
+	qr_share_text: ({ amount, appName }: { amount: string; appName: string }) =>
+		`${amount} of credit through ${appName}.`,
+	qr_share_text_with_note: ({
+		amount,
+		note,
+		appName
+	}: {
+		amount: string;
+		note: string;
+		appName: string;
+	}) => `${amount} for "${note}" through ${appName}.`,
+	qr_copy_link: () => 'Copy link',
+	qr_share: () => 'Share',
+	send_qr_caption: () => 'Scan to accept',
+	send_qr_expired: () => 'Expired',
+	send_cancel: () => 'Cancel',
+	send_back_home: () => 'Back home',
+	send_declined: () => 'Declined',
+	send_done: () => 'Done'
+}));
+
+const mockData = {
+	unitSymbol: '€',
+	decimalPlaces: 2,
+	appName: 'Mutuvia',
+	needsConsent: false,
+	qrTtlSeconds: 600
+};
+
+describe('send page – issue #56: share text amount', () => {
+	let enhanceMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		const formsModule = await import('$app/forms');
+		enhanceMock = vi.mocked(formsModule.enhance);
+		enhanceMock.mockClear();
+		enhanceMock.mockReturnValue({ destroy: vi.fn() });
+	});
+
+	test('amount is preserved after createQr form submission (regression: issue #56)', async () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const { getByRole } = render(SendPage, { props: { data: mockData as any, form: null } });
+
+		// Fill in the amount
+		const amountInput = getByRole('spinbutton'); // type="number"
+		await fireEvent.input(amountInput, { target: { value: '100' } });
+		expect(amountInput).toHaveValue(100); // sanity check
+
+		// The enhance action should have been registered for the createQr form
+		expect(enhanceMock).toHaveBeenCalled();
+		const [formElement, submitCallback] = enhanceMock.mock.calls[0] as [
+			HTMLFormElement,
+			((...args: unknown[]) => unknown) | undefined
+		];
+
+		// Simulate SvelteKit's use:enhance lifecycle on a successful action.
+		// By default (no `{ reset: false }`), SvelteKit calls form.reset() after update().
+		// The fix supplies a callback that passes `{ reset: false }` to prevent this.
+		const updateMock = vi.fn().mockImplementation(async (opts?: { reset?: boolean }) => {
+			if (opts?.reset !== false) {
+				// Default SvelteKit behavior: reset the form, clearing bound inputs
+				formElement.reset();
+			}
+		});
+
+		if (submitCallback) {
+			// Component provides a custom enhance callback — invoke the full chain
+			const innerHandler = submitCallback({
+				action: new URL('http://localhost/?/createQr'),
+				formData: new FormData(),
+				formElement,
+				controller: new AbortController(),
+				submitter: null,
+				cancel: vi.fn()
+			});
+			if (innerHandler && typeof innerHandler === 'function') {
+				await (innerHandler as (opts: unknown) => Promise<void>)({
+					update: updateMock,
+					formData: new FormData(),
+					formElement,
+					action: new URL('http://localhost/?/createQr'),
+					result: { type: 'success', status: 200, data: {} },
+					applyAction: vi.fn()
+				});
+			}
+		} else {
+			// No custom callback: default use:enhance resets the form on success
+			formElement.reset();
+		}
+
+		// After form submission, the amount should still reflect what the user entered.
+		// Without the fix, the form reset clears the bound `amount` state → 0.
+		expect(amountInput).toHaveValue(100);
+	});
+});


### PR DESCRIPTION
## Summary

- `use:enhance` default behavior resets form inputs on successful submission, clearing the bound `amount`/`note` `$state` before `formattedAmount` is computed — causing the share/copy text to show "€ 0.00"
- Fix: add `() => async ({ update }) => update({ reset: false })` callback to the `createQr` form in both send and receive flows
- Adds regression tests (`page.svelte.test.ts`) for each route that simulate the SvelteKit form-reset lifecycle and assert the amount is preserved

## Test plan

- [ ] `bun --bun vitest run` — 2 new regression tests pass (were RED before fix)
- [ ] `bun run check` — no type errors
- [ ] `bun run lint` — clean
- [ ] Manual: send flow → enter amount → Generate QR → Share/Copy → verify correct amount appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)