### PR TITLE
feat: friendly 500 and 404 error pages

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -200,5 +200,12 @@
 	"og_send_title": "Zahlung von {amount}",
 	"og_receive_title": "Anforderung von {amount}",
 	"og_description": "Gegenseitiger Kredit für deine Gemeinschaft",
-	"og_expired_title": "Link abgelaufen"
+	"og_expired_title": "Link abgelaufen",
+
+	"error_not_found_title": "Seite nicht gefunden",
+	"error_not_found_body": "Wir konnten diese Seite nicht finden. Sie wurde möglicherweise verschoben oder existiert nicht mehr.",
+	"error_server_title": "Etwas ist schiefgelaufen",
+	"error_server_body": "Wir wurden benachrichtigt und arbeiten daran. Bitte versuche es erneut.",
+	"error_go_home": "Zur Startseite",
+	"error_try_again": "Erneut versuchen"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -222,5 +222,12 @@
 	"og_send_title": "Payment of {amount}",
 	"og_receive_title": "Request for {amount}",
 	"og_description": "Mutual credit for your community",
-	"og_expired_title": "Link expired"
+	"og_expired_title": "Link expired",
+
+	"error_not_found_title": "Page not found",
+	"error_not_found_body": "We couldn't find this page. It may have moved or no longer exists.",
+	"error_server_title": "Something went wrong",
+	"error_server_body": "We've been notified and are looking into it. Please try again.",
+	"error_go_home": "Go to home",
+	"error_try_again": "Try again"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -222,5 +222,12 @@
 	"og_send_title": "Betaling van {amount}",
 	"og_receive_title": "Verzoek voor {amount}",
 	"og_description": "Wederzijds krediet voor jouw gemeenschap",
-	"og_expired_title": "Link verlopen"
+	"og_expired_title": "Link verlopen",
+
+	"error_not_found_title": "Pagina niet gevonden",
+	"error_not_found_body": "We konden deze pagina niet vinden. Mogelijk is deze verplaatst of bestaat deze niet meer.",
+	"error_server_title": "Er ging iets mis",
+	"error_server_body": "We zijn op de hoogte gebracht en kijken ernaar. Probeer het opnieuw.",
+	"error_go_home": "Naar startpagina",
+	"error_try_again": "Opnieuw proberen"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -222,5 +222,12 @@
 	"og_send_title": "Pagamento de {amount}",
 	"og_receive_title": "Pedido de {amount}",
 	"og_description": "Crédito mútuo para a tua comunidade",
-	"og_expired_title": "Link expirado"
+	"og_expired_title": "Link expirado",
+
+	"error_not_found_title": "Página não encontrada",
+	"error_not_found_body": "Não conseguimos encontrar esta página. Pode ter sido movida ou já não existir.",
+	"error_server_title": "Algo correu mal",
+	"error_server_body": "Já fomos notificados e estamos a investigar. Por favor, tenta novamente.",
+	"error_go_home": "Ir para o início",
+	"error_try_again": "Tentar novamente"
 }

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import * as m from '$lib/paraglide/messages.js';
+	import { Button } from '$lib/components/ui/button';
+	import SearchIcon from '@lucide/svelte/icons/search';
+	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
+	import HomeIcon from '@lucide/svelte/icons/home';
+	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
+
+	const is404 = $derived(page.status === 404);
+</script>
+
+<div class="flex min-h-dvh flex-col items-center justify-center bg-[#FAF8F3] px-6 pb-8">
+	<div class="mx-auto w-full max-w-md text-center">
+		<div
+			class="mx-auto mb-5 flex h-20 w-20 items-center justify-center rounded-full bg-[#2D4A32] shadow-lg shadow-[#2D4A32]/25"
+		>
+			{#if is404}
+				<SearchIcon class="h-9 w-9 text-white" stroke-width={2} />
+			{:else}
+				<TriangleAlertIcon class="h-9 w-9 text-white" stroke-width={2} />
+			{/if}
+		</div>
+		<h1 class="mb-2.5 font-serif text-[26px] font-semibold text-[#1E2820]">
+			{#if is404}
+				{m.error_not_found_title()}
+			{:else}
+				{m.error_server_title()}
+			{/if}
+		</h1>
+		<p class="mb-8 text-[15px] font-light text-[#3A4A3D]">
+			{#if is404}
+				{m.error_not_found_body()}
+			{:else}
+				{m.error_server_body()}
+			{/if}
+		</p>
+		<Button
+			href="/home"
+			class="w-full rounded-xl bg-[#2D4A32] py-6 text-base font-medium text-white hover:bg-[#3D6145]"
+		>
+			<HomeIcon class="mr-2 h-4 w-4" />
+			{m.error_go_home()}
+		</Button>
+		{#if !is404}
+			<Button variant="ghost" class="mt-3 w-full" onclick={() => location.reload()}>
+				<RefreshCwIcon class="mr-2 h-4 w-4" />
+				{m.error_try_again()}
+			</Button>
+		{/if}
+	</div>
+</div>

--- a/src/routes/error-page.test.ts
+++ b/src/routes/error-page.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, test } from 'vitest';
+import en from '../../messages/en.json';
+import pt from '../../messages/pt.json';
+import nl from '../../messages/nl.json';
+import de from '../../messages/de.json';
+
+const ERROR_KEYS = [
+	'error_not_found_title',
+	'error_not_found_body',
+	'error_server_title',
+	'error_server_body',
+	'error_go_home',
+	'error_try_again'
+] as const;
+
+type Messages = Record<string, string>;
+
+describe('error page i18n', () => {
+	test.each([
+		['en', en as Messages],
+		['pt', pt as Messages],
+		['nl', nl as Messages],
+		['de', de as Messages]
+	])('%s has all error page keys with non-empty values', (locale, messages) => {
+		for (const key of ERROR_KEYS) {
+			expect(messages[key], `key "${key}" is missing or empty in ${locale}`).toBeTruthy();
+		}
+	});
+});


### PR DESCRIPTION
Closes #55

## Summary

- Adds `src/routes/+error.svelte` — a single root-level error page that handles both 404 and 500+ errors
- **404**: search icon, "Page not found", "Go to home" button
- **500+**: alert icon, "Something went wrong", Sentry reassurance ("We've been notified…"), "Go to home" + "Try again" buttons
- Adds i18n keys to all four locales (EN, PT, NL, DE)
- Adds a unit test verifying all locale files have the required keys

## Test plan

- [ ] `bun run dev` → visit `/does-not-exist` → friendly 404 page renders
- [ ] Temporarily throw in a load function → friendly 500 page renders with "Try again" button
- [ ] "Go to home" navigates to `/home`
- [ ] "Try again" reloads the page
- [ ] `bun test` passes (15 tests)
- [ ] `bun run check` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)