### PR TITLE
fix: use svelteKitHandler to resolve "No request state found"

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -9,6 +9,8 @@ import type { Handle, ServerInit } from '@sveltejs/kit';
 import { config } from '$lib/config';
 import { sequence } from '@sveltejs/kit/hooks';
 import { paraglideMiddleware } from '$lib/paraglide/server';
+import { svelteKitHandler } from 'better-auth/svelte-kit';
+import { building } from '$app/environment';
 
 /**
  * Run Drizzle migrations once at server startup, before any request is served.
@@ -38,11 +40,6 @@ const i18nHandle: Handle = ({ event, resolve }) => {
 };
 
 const authHandle: Handle = async ({ event, resolve }) => {
-	// Better Auth API routes
-	if (event.url.pathname.startsWith('/api/auth')) {
-		return auth.handler(event.request);
-	}
-
 	// Get session from Better Auth
 	const session = await auth.api.getSession({ headers: event.request.headers });
 
@@ -64,7 +61,10 @@ const authHandle: Handle = async ({ event, resolve }) => {
 		event.locals.appUser = null;
 	}
 
-	return resolve(event);
+	// svelteKitHandler replaces the manual auth.handler() + resolve() calls.
+	// It sets up Better Auth's AsyncLocalStorage request state context, routes
+	// /api/auth/* to the auth handler, and delegates all other requests to resolve().
+	return svelteKitHandler({ event, resolve, auth, building });
 };
 
 export const handle = sequence(Sentry.sentryHandle(), i18nHandle, authHandle);


### PR DESCRIPTION
Fixes #57.

## Summary

- Replaces the manual `auth.handler(event.request)` call and `if (event.url.pathname.startsWith('/api/auth'))` block in `hooks.server.ts` with Better Auth's official `svelteKitHandler` from `better-auth/svelte-kit`
- `svelteKitHandler` properly initialises `better-call`'s `AsyncLocalStorage` request state context, which the manual handler did not — causing the "No request state found" error in production
- Routing of `/api/auth/*` requests is now handled internally by `svelteKitHandler`, so the explicit path check is no longer needed

## Test plan

- [ ] `bun run check` passes (0 errors)
- [ ] `bun run lint` passes
- [ ] Auth flows (phone OTP, email OTP) still work end-to-end
- [ ] Authenticated routes (`/home`, `/send`, `/receive`, etc.) still load session correctly
- [ ] "No request state found" errors no longer appear in production logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)