### PR TITLE
feat: implement email login via Prelude Verify

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -19,8 +19,8 @@ BETTER_AUTH_SECRET=change-me-to-a-random-secret!!
 # DATABASE_URL=postgresql://mutuvia:change-me@postgres:5432/mutuvia
 # POSTGRES_PASSWORD=change-me
 
-# ── Prelude (SMS OTP) ─────────────────────────────────────────────────────────
-# Required for SMS delivery in production. Without this, OTPs are only logged.
+# ── Prelude (SMS & Email OTP) ─────────────────────────────────────────────────
+# Required for OTP delivery in production (SMS and email). Without this, OTPs are only logged.
 PRELUDE_API_TOKEN=
 
 # ── Optional ──────────────────────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,8 @@ QR_TTL_SECONDS=259200  # 3 days
 # REQUIRED: min 32 characters, used to sign QR JWTs
 QR_JWT_SECRET=change-me-to-a-random-32-char-secret!!
 
-# ── Prelude (SMS OTP) ──
-# Required for production SMS delivery. In dev, OTPs are logged to console.
+# ── Prelude (SMS & Email OTP) ──
+# Required for production OTP delivery (SMS and email). In dev, OTPs are logged to console.
 PRELUDE_API_TOKEN=
 
 # ── Community ──

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -22,10 +22,23 @@ export const auth = betterAuth({
 	plugins: [
 		emailOTP({
 			sendVerificationOTP: async ({ email, otp }) => {
-				if (process.env.NODE_ENV !== 'production') {
-					console.log(`[DEV] Email OTP for ${email}: ${otp}`);
+				if (!prelude) {
+					if (process.env.NODE_ENV !== 'production') {
+						console.log(`[DEV] Email OTP for ${email}: ${otp}`);
+					} else {
+						console.error('PRELUDE_API_TOKEN not configured');
+					}
+					return;
 				}
-			}
+				const result = await prelude.verification.create({
+					target: { type: 'email_address', value: email },
+					options: { code_size: 6, custom_code: otp }
+				});
+				if (result.status === 'blocked') {
+					console.error(`Prelude blocked verification for ${email}: ${result.reason}`);
+				}
+			},
+			otpLength: 6
 		}),
 		phoneNumber({
 			signUpOnVerification: {


### PR DESCRIPTION
## Summary

- Replaces the email OTP stub in `emailOTP` plugin with Prelude Verify integration
- Uses `custom_code` option to pass Better Auth's generated OTP to Prelude, which delivers it by email — Better Auth handles verification internally (the `emailOTP` plugin has no `verifyOTP` callback, unlike `phoneNumber`)
- Dev fallback preserved: OTPs console-logged when `PRELUDE_API_TOKEN` unset

## Notes

- No UI, schema, or client-side changes needed — the full email login flow was already in place
- Requires Prelude account to have email verification and `custom_code` enabled (contact support@prelude.so)

## Test plan

- [ ] Dev mode (no `PRELUDE_API_TOKEN`): go through `/onboarding/email` → `/onboarding/otp`, verify OTP appears in console as `[DEV] Email OTP for ...`
- [ ] Production (with `PRELUDE_API_TOKEN`, email + `custom_code` enabled): verify OTP email arrives and code signs in successfully
- [ ] `bun run check` passes (0 errors)
- [ ] `bunx playwright test` passes

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)