### PR TITLE
feat: replace cancel X with chevron nav + add cancel confirmation dialog

### DIFF
--- a/e2e/pending-item-navigation.test.ts
+++ b/e2e/pending-item-navigation.test.ts
@@ -1,0 +1,88 @@
+import { expect, type BrowserContext } from '@playwright/test';
+import { test, goto, setupAuthenticatedUser, createPendingQr, getAppUserId } from './test-utils.js';
+import { sqlite } from './auth.js';
+
+test.describe.serial('Pending item navigation', () => {
+	let userStorage: Awaited<ReturnType<BrowserContext['storageState']>>;
+	let betterAuthUserId: string;
+
+	test.beforeAll(async ({ browser, email }, testInfo) => {
+		const baseURL = testInfo.project.use.baseURL!;
+		const ctx = await browser.newContext({ baseURL });
+		betterAuthUserId = await setupAuthenticatedUser(ctx, email('user'), 'Test User');
+		userStorage = await ctx.storageState();
+		await ctx.close();
+	});
+
+	test('home screen — pending send row navigates to /send detail page', async ({
+		browser
+	}, testInfo) => {
+		const baseURL = testInfo.project.use.baseURL!;
+		const appUserId = getAppUserId(betterAuthUserId);
+		const { qrId } = await createPendingQr(appUserId, 'Test User');
+
+		const ctx = await browser.newContext({ storageState: userStorage, baseURL });
+		const page = await ctx.newPage();
+
+		try {
+			await goto(page, '/home');
+
+			// The pending send row is a link showing "Sending €5.00" (or equivalent)
+			const pendingLink = page.getByRole('link', { name: /Sending/ });
+			await expect(pendingLink).toBeVisible({ timeout: 10_000 });
+			await pendingLink.click();
+
+			// Should navigate to /send?qrId=<qrId>
+			await expect(page).toHaveURL(new RegExp(`/send\\?qrId=${qrId}`), { timeout: 10_000 });
+
+			// QR step is visible: expiry countdown text is rendered
+			await expect(page.getByText(/Expires/)).toBeVisible({ timeout: 10_000 });
+		} finally {
+			// Clean up the pending QR so it doesn't leak into other tests
+			sqlite.prepare(`DELETE FROM pending_qr WHERE id = ?`).run(qrId);
+			await ctx.close();
+		}
+	});
+
+	test('history screen — pending receive row navigates to /receive detail page', async ({
+		browser
+	}, testInfo) => {
+		const baseURL = testInfo.project.use.baseURL!;
+		const appUserId = getAppUserId(betterAuthUserId);
+
+		// createPendingQr only supports direction='send', so insert receive direction directly
+		const qrId = crypto.randomUUID();
+		const now = Math.floor(Date.now() / 1000);
+		sqlite
+			.prepare(
+				`INSERT INTO pending_qr (id, initiating_user_id, direction, amount, status, created_at, expires_at)
+				 VALUES (?, ?, 'receive', 750, 'pending', ?, ?)`
+			)
+			.run(qrId, appUserId, now, now + 600);
+
+		const ctx = await browser.newContext({ storageState: userStorage, baseURL });
+		const page = await ctx.newPage();
+
+		try {
+			await goto(page, '/history');
+
+			// Switch to the Pending tab
+			await page.getByRole('button', { name: 'Pending' }).click();
+
+			// The pending receive row is a link showing "Requesting €7.50" (or equivalent)
+			const pendingLink = page.getByRole('link', { name: /Requesting/ });
+			await expect(pendingLink).toBeVisible({ timeout: 10_000 });
+			await pendingLink.click();
+
+			// Should navigate to /receive?qrId=<qrId>
+			await expect(page).toHaveURL(new RegExp(`/receive\\?qrId=${qrId}`), { timeout: 10_000 });
+
+			// QR step is visible: expiry countdown text is rendered
+			await expect(page.getByText(/Expires/)).toBeVisible({ timeout: 10_000 });
+		} finally {
+			// Clean up the pending QR so it doesn't leak into other tests
+			sqlite.prepare(`DELETE FROM pending_qr WHERE id = ?`).run(qrId);
+			await ctx.close();
+		}
+	});
+});

--- a/messages/de.json
+++ b/messages/de.json
@@ -104,6 +104,10 @@
 	"send_qr_caption": "Zeige das der anderen Person. Sie scannt es, um anzunehmen.",
 	"send_qr_expired": "Abgelaufen — tippe, um zurückzugehen.",
 	"send_cancel": "Abbrechen",
+	"cancel_confirm_title": "Diese Transaktion abbrechen?",
+	"cancel_confirm_body": "Der QR-Code wird ungültig und kann nicht mehr verwendet werden.",
+	"cancel_confirm_yes": "Ja, abbrechen",
+	"cancel_confirm_dismiss": "Weiter warten",
 	"send_done": "Fertig. Du hast {amount} an {name} gesendet.",
 	"send_declined": "Dein Kredit wurde abgelehnt.",
 	"send_back_home": "Zurück zur Startseite",
@@ -167,7 +171,6 @@
 	"home_pending_send": "Sende {amount}",
 	"home_pending_receive": "Fordere {amount} an",
 	"home_pending_expired": "Abgelaufen",
-	"pending_cancel_aria": "Ausstehende Transaktion abbrechen",
 	"history_pending": "Ausstehend",
 
 	"locale_name": "Deutsch",

--- a/messages/en.json
+++ b/messages/en.json
@@ -104,6 +104,10 @@
 	"send_qr_caption": "Show this to the other person. They scan it to accept.",
 	"send_qr_expired": "Expired — tap to go back.",
 	"send_cancel": "Cancel",
+	"cancel_confirm_title": "Cancel this transaction?",
+	"cancel_confirm_body": "The QR code will be invalidated and can no longer be used.",
+	"cancel_confirm_yes": "Yes, cancel",
+	"cancel_confirm_dismiss": "Keep waiting",
 	"send_done": "Done. You sent {amount} to {name}.",
 	"send_declined": "Your credit was declined.",
 	"send_back_home": "Back to home",
@@ -167,7 +171,6 @@
 	"home_pending_send": "Sending {amount}",
 	"home_pending_receive": "Requesting {amount}",
 	"home_pending_expired": "Expired",
-	"pending_cancel_aria": "Cancel pending transaction",
 	"history_pending": "Pending",
 
 	"locale_name": "English",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -104,6 +104,10 @@
 	"send_qr_caption": "Laat dit aan de andere persoon zien. Die scant het om te accepteren.",
 	"send_qr_expired": "Verlopen — tik om terug te gaan.",
 	"send_cancel": "Annuleren",
+	"cancel_confirm_title": "Deze transactie annuleren?",
+	"cancel_confirm_body": "De QR-code wordt ongeldig en kan niet meer worden gebruikt.",
+	"cancel_confirm_yes": "Ja, annuleren",
+	"cancel_confirm_dismiss": "Blijven wachten",
 	"send_done": "Klaar. Je hebt {amount} gestuurd naar {name}.",
 	"send_declined": "Je krediet is geweigerd.",
 	"send_back_home": "Terug naar home",
@@ -167,7 +171,6 @@
 	"home_pending_send": "Versturen {amount}",
 	"home_pending_receive": "Aanvragen {amount}",
 	"home_pending_expired": "Verlopen",
-	"pending_cancel_aria": "Lopende transactie annuleren",
 	"history_pending": "In behandeling",
 
 	"locale_name": "Nederlands",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -104,6 +104,10 @@
 	"send_qr_caption": "Mostra isto à outra pessoa. Ela digitaliza para aceitar.",
 	"send_qr_expired": "Expirado — toca para voltar.",
 	"send_cancel": "Cancelar",
+	"cancel_confirm_title": "Cancelar esta transação?",
+	"cancel_confirm_body": "O código QR será invalidado e não poderá ser utilizado.",
+	"cancel_confirm_yes": "Sim, cancelar",
+	"cancel_confirm_dismiss": "Continuar à espera",
 	"send_done": "Feito. Enviaste {amount} a {name}.",
 	"send_declined": "O teu crédito foi recusado.",
 	"send_back_home": "Voltar ao início",
@@ -167,7 +171,6 @@
 	"home_pending_send": "Enviando {amount}",
 	"home_pending_receive": "Solicitando {amount}",
 	"home_pending_expired": "Expirado",
-	"pending_cancel_aria": "Cancelar transação pendente",
 	"history_pending": "Pendente",
 
 	"locale_name": "Português",

--- a/src/routes/(app)/history/+page.server.ts
+++ b/src/routes/(app)/history/+page.server.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import type { PageServerLoad, Actions } from './$types';
+import type { PageServerLoad } from './$types';
 import { formatAmount } from '$lib/server/currency';
 import { db } from '$lib/server/db';
 import { transactions, appUsers } from '$lib/server/schema';
 import { eq, or, desc } from 'drizzle-orm';
-import { getPendingItems, cancelPendingQr } from '$lib/server/pending-qr';
+import { getPendingItems } from '$lib/server/pending-qr';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	const userId = locals.appUser!.id;
@@ -49,13 +49,4 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const pendingItems = await getPendingItems(userId);
 
 	return { transactions: txList, pendingItems };
-};
-
-export const actions: Actions = {
-	cancelQr: async ({ request, locals }) => {
-		const data = await request.formData();
-		const qrId = data.get('qrId') as string;
-		if (!qrId) return;
-		await cancelPendingQr(qrId, locals.appUser!.id);
-	}
 };

--- a/src/routes/(app)/history/+page.svelte
+++ b/src/routes/(app)/history/+page.svelte
@@ -53,9 +53,9 @@
 		{:else}
 			<div class="space-y-0">
 				{#each data.pendingItems as item (item.id)}
-					<div class="flex items-center justify-between border-b py-3 last:border-b-0">
-						{#if item.isExpired}
-							<div class="flex-1 opacity-60">
+					{#if item.isExpired}
+						<div class="flex items-center justify-between border-b py-3 opacity-60 last:border-b-0">
+							<div>
 								<p class="text-sm font-medium">
 									{item.direction === 'send'
 										? m.home_pending_send({ amount: item.formattedAmount })
@@ -65,11 +65,14 @@
 									<p class="max-w-[200px] truncate text-xs text-muted-foreground">{item.note}</p>
 								{/if}
 							</div>
-						{:else}
-							<a
-								href="/{item.direction === 'send' ? 'send' : 'receive'}?qrId={item.id}"
-								class="flex-1"
-							>
+							<p class="text-xs text-red-600">{m.home_pending_expired()}</p>
+						</div>
+					{:else}
+						<a
+							href="/{item.direction === 'send' ? 'send' : 'receive'}?qrId={item.id}"
+							class="flex items-center justify-between border-b py-3 last:border-b-0"
+						>
+							<div>
 								<p class="text-sm font-medium">
 									{item.direction === 'send'
 										? m.home_pending_send({ amount: item.formattedAmount })
@@ -78,21 +81,17 @@
 								{#if item.note}
 									<p class="max-w-[200px] truncate text-xs text-muted-foreground">{item.note}</p>
 								{/if}
-							</a>
-						{/if}
-						<div class="flex items-center gap-2">
-							{#if item.isExpired}
-								<p class="text-xs text-red-600">{m.home_pending_expired()}</p>
-							{:else}
+							</div>
+							<div class="flex items-center gap-2">
 								<p class="text-xs text-muted-foreground">
 									{m.qr_expires({
 										time: formatTimeRemaining(remainingSeconds(item.expiresAt), getLocale())
 									})}
 								</p>
 								<ChevronRightIcon class="h-4 w-4 text-muted-foreground" />
-							{/if}
-						</div>
-					</div>
+							</div>
+						</a>
+					{/if}
 				{/each}
 			</div>
 		{/if}

--- a/src/routes/(app)/history/+page.svelte
+++ b/src/routes/(app)/history/+page.svelte
@@ -2,10 +2,9 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { getLocale } from '$lib/paraglide/runtime.js';
 	import { goto } from '$app/navigation';
-	import { enhance } from '$app/forms';
 	import { Button } from '$lib/components/ui/button';
 	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
-	import XIcon from '@lucide/svelte/icons/x';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import { formatTimeRemaining, remainingSeconds } from '$lib/format-time';
 
 	let { data } = $props();
@@ -82,27 +81,16 @@
 							</a>
 						{/if}
 						<div class="flex items-center gap-2">
-							<div class="text-right">
-								{#if item.isExpired}
-									<p class="text-xs text-red-600">{m.home_pending_expired()}</p>
-								{:else}
-									<p class="text-xs text-muted-foreground">
-										{m.qr_expires({
-											time: formatTimeRemaining(remainingSeconds(item.expiresAt), getLocale())
-										})}
-									</p>
-								{/if}
-							</div>
-							<form method="POST" action="?/cancelQr" use:enhance>
-								<input type="hidden" name="qrId" value={item.id} />
-								<button
-									type="submit"
-									class="text-muted-foreground hover:text-red-600"
-									aria-label={m.pending_cancel_aria()}
-								>
-									<XIcon class="h-4 w-4" />
-								</button>
-							</form>
+							{#if item.isExpired}
+								<p class="text-xs text-red-600">{m.home_pending_expired()}</p>
+							{:else}
+								<p class="text-xs text-muted-foreground">
+									{m.qr_expires({
+										time: formatTimeRemaining(remainingSeconds(item.expiresAt), getLocale())
+									})}
+								</p>
+								<ChevronRightIcon class="h-4 w-4 text-muted-foreground" />
+							{/if}
 						</div>
 					</div>
 				{/each}

--- a/src/routes/(app)/home/+page.server.ts
+++ b/src/routes/(app)/home/+page.server.ts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import type { PageServerLoad, Actions } from './$types';
+import type { PageServerLoad } from './$types';
 import { getBalance } from '$lib/server/balance';
 import { formatAmount } from '$lib/server/currency';
 import { db } from '$lib/server/db';
 import { transactions, appUsers } from '$lib/server/schema';
 import { eq, or, desc } from 'drizzle-orm';
-import { getPendingItems, cancelPendingQr } from '$lib/server/pending-qr';
+import { getPendingItems } from '$lib/server/pending-qr';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	const userId = locals.appUser!.id;
@@ -60,13 +60,4 @@ export const load: PageServerLoad = async ({ locals }) => {
 		recentTransactions,
 		pendingItems
 	};
-};
-
-export const actions: Actions = {
-	cancelQr: async ({ request, locals }) => {
-		const data = await request.formData();
-		const qrId = data.get('qrId') as string;
-		if (!qrId) return;
-		await cancelPendingQr(qrId, locals.appUser!.id);
-	}
 };

--- a/src/routes/(app)/home/+page.svelte
+++ b/src/routes/(app)/home/+page.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { goto, invalidateAll } from '$app/navigation';
-	import { enhance } from '$app/forms';
 	import { sseManager } from '$lib/sse-client';
 	import { Card } from '$lib/components/ui/card';
 	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
 	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
 	import ScanLineIcon from '@lucide/svelte/icons/scan-line';
-	import XIcon from '@lucide/svelte/icons/x';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import { NavMenu } from '$lib/components/ui/nav-menu';
 
 	import { browser } from '$app/environment';
@@ -177,17 +176,8 @@
 									time: formatTimeRemaining(remainingSeconds(item.expiresAt), getLocale())
 								})}
 							</p>
+							<ChevronRightIcon class="h-4 w-4 text-muted-foreground" />
 						{/if}
-						<form method="POST" action="?/cancelQr" use:enhance>
-							<input type="hidden" name="qrId" value={item.id} />
-							<button
-								type="submit"
-								class="text-muted-foreground hover:text-red-600"
-								aria-label={m.pending_cancel_aria()}
-							>
-								<XIcon class="h-4 w-4" />
-							</button>
-						</form>
 					</div>
 				</div>
 			{/each}

--- a/src/routes/(app)/home/+page.svelte
+++ b/src/routes/(app)/home/+page.svelte
@@ -140,9 +140,9 @@
 		</div>
 		<div class="mb-4 space-y-0">
 			{#each data.pendingItems as item (item.id)}
-				<div class="flex items-center justify-between border-b py-3 last:border-b-0">
-					{#if item.isExpired}
-						<div class="flex-1 opacity-60">
+				{#if item.isExpired}
+					<div class="flex items-center justify-between border-b py-3 opacity-60 last:border-b-0">
+						<div>
 							<p class="text-sm font-medium">
 								{item.direction === 'send'
 									? m.home_pending_send({ amount: item.formattedAmount })
@@ -152,11 +152,14 @@
 								<p class="text-xs text-muted-foreground">{item.note}</p>
 							{/if}
 						</div>
-					{:else}
-						<a
-							href="/{item.direction === 'send' ? 'send' : 'receive'}?qrId={item.id}"
-							class="flex-1"
-						>
+						<p class="text-xs text-red-600">{m.home_pending_expired()}</p>
+					</div>
+				{:else}
+					<a
+						href="/{item.direction === 'send' ? 'send' : 'receive'}?qrId={item.id}"
+						class="flex items-center justify-between border-b py-3 last:border-b-0"
+					>
+						<div>
 							<p class="text-sm font-medium">
 								{item.direction === 'send'
 									? m.home_pending_send({ amount: item.formattedAmount })
@@ -165,21 +168,17 @@
 							{#if item.note}
 								<p class="text-xs text-muted-foreground">{item.note}</p>
 							{/if}
-						</a>
-					{/if}
-					<div class="flex items-center gap-2">
-						{#if item.isExpired}
-							<p class="text-xs text-red-600">{m.home_pending_expired()}</p>
-						{:else}
+						</div>
+						<div class="flex items-center gap-2">
 							<p class="text-xs text-muted-foreground">
 								{m.qr_expires({
 									time: formatTimeRemaining(remainingSeconds(item.expiresAt), getLocale())
 								})}
 							</p>
 							<ChevronRightIcon class="h-4 w-4 text-muted-foreground" />
-						{/if}
-					</div>
-				</div>
+						</div>
+					</a>
+				{/if}
 			{/each}
 		</div>
 	{/if}

--- a/src/routes/(app)/receive/+page.svelte
+++ b/src/routes/(app)/receive/+page.svelte
@@ -6,6 +6,7 @@
 	import { enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
 	import { Button } from '$lib/components/ui/button';
+	import * as Dialog from '$lib/components/ui/dialog';
 	import { CopyButton } from '$lib/components/ui/copy-button';
 	import { Card } from '$lib/components/ui/card';
 	import { Input } from '$lib/components/ui/input';
@@ -36,6 +37,7 @@
 	let qrUrl = $state('');
 	let createQrLoading = $state(false);
 	let cancelLoading = $state(false);
+	let cancelDialogOpen = $state(false);
 	let canShare = $derived(browser && typeof navigator.share === 'function');
 	let currencyFormatter = $derived(
 		new Intl.NumberFormat(getLocale(), { style: 'currency', currency: data.unitCode })
@@ -237,34 +239,52 @@
 						<XIcon class="mr-2 h-4 w-4" />
 						{m.qr_close()}
 					</Button>
-					<form
-						method="POST"
-						action="?/cancel"
-						use:enhance={() => {
-							flushSync(() => {
-								cancelLoading = true;
-							});
-							return async ({ update }) => {
-								try {
-									await update();
-								} finally {
-									flushSync(() => {
-										cancelLoading = false;
-									});
-								}
-							};
-						}}
+					<Button
+						type="button"
+						variant="ghost"
+						class="text-sm text-muted-foreground"
+						onclick={() => (cancelDialogOpen = true)}
 					>
-						<input type="hidden" name="qrId" value={qrId} />
-						<Button
-							type="submit"
-							loading={cancelLoading}
-							variant="ghost"
-							class="text-sm text-muted-foreground"
-						>
-							{m.send_cancel()}
-						</Button>
-					</form>
+						{m.send_cancel()}
+					</Button>
+					<Dialog.Dialog bind:open={cancelDialogOpen}>
+						<Dialog.DialogContent showCloseButton={false}>
+							<Dialog.DialogHeader>
+								<Dialog.DialogTitle>{m.cancel_confirm_title()}</Dialog.DialogTitle>
+								<Dialog.DialogDescription>{m.cancel_confirm_body()}</Dialog.DialogDescription>
+							</Dialog.DialogHeader>
+							<Dialog.DialogFooter>
+								<Dialog.DialogClose>
+									{#snippet child({ props })}
+										<Button variant="outline" {...props}>{m.cancel_confirm_dismiss()}</Button>
+									{/snippet}
+								</Dialog.DialogClose>
+								<form
+									method="POST"
+									action="?/cancel"
+									use:enhance={() => {
+										flushSync(() => {
+											cancelLoading = true;
+										});
+										return async ({ update }) => {
+											try {
+												await update();
+											} finally {
+												flushSync(() => {
+													cancelLoading = false;
+												});
+											}
+										};
+									}}
+								>
+									<input type="hidden" name="qrId" value={qrId} />
+									<Button type="submit" loading={cancelLoading} variant="destructive">
+										{m.cancel_confirm_yes()}
+									</Button>
+								</form>
+							</Dialog.DialogFooter>
+						</Dialog.DialogContent>
+					</Dialog.Dialog>
 				</div>
 			{/if}
 		</div>

--- a/src/routes/(app)/send/+page.svelte
+++ b/src/routes/(app)/send/+page.svelte
@@ -6,6 +6,7 @@
 	import { enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
 	import { Button } from '$lib/components/ui/button';
+	import * as Dialog from '$lib/components/ui/dialog';
 	import { CopyButton } from '$lib/components/ui/copy-button';
 	import { Card } from '$lib/components/ui/card';
 	import { Input } from '$lib/components/ui/input';
@@ -37,6 +38,7 @@
 	let consentLoading = $state(false);
 	let createQrLoading = $state(false);
 	let cancelLoading = $state(false);
+	let cancelDialogOpen = $state(false);
 	let canShare = $derived(browser && typeof navigator.share === 'function');
 	let currencyFormatter = $derived(
 		new Intl.NumberFormat(getLocale(), { style: 'currency', currency: data.unitCode })
@@ -283,34 +285,52 @@
 						<XIcon class="mr-2 h-4 w-4" />
 						{m.qr_close()}
 					</Button>
-					<form
-						method="POST"
-						action="?/cancel"
-						use:enhance={() => {
-							flushSync(() => {
-								cancelLoading = true;
-							});
-							return async ({ update }) => {
-								try {
-									await update();
-								} finally {
-									flushSync(() => {
-										cancelLoading = false;
-									});
-								}
-							};
-						}}
+					<Button
+						type="button"
+						variant="ghost"
+						class="text-sm text-muted-foreground"
+						onclick={() => (cancelDialogOpen = true)}
 					>
-						<input type="hidden" name="qrId" value={qrId} />
-						<Button
-							type="submit"
-							loading={cancelLoading}
-							variant="ghost"
-							class="text-sm text-muted-foreground"
-						>
-							{m.send_cancel()}
-						</Button>
-					</form>
+						{m.send_cancel()}
+					</Button>
+					<Dialog.Dialog bind:open={cancelDialogOpen}>
+						<Dialog.DialogContent showCloseButton={false}>
+							<Dialog.DialogHeader>
+								<Dialog.DialogTitle>{m.cancel_confirm_title()}</Dialog.DialogTitle>
+								<Dialog.DialogDescription>{m.cancel_confirm_body()}</Dialog.DialogDescription>
+							</Dialog.DialogHeader>
+							<Dialog.DialogFooter>
+								<Dialog.DialogClose>
+									{#snippet child({ props })}
+										<Button variant="outline" {...props}>{m.cancel_confirm_dismiss()}</Button>
+									{/snippet}
+								</Dialog.DialogClose>
+								<form
+									method="POST"
+									action="?/cancel"
+									use:enhance={() => {
+										flushSync(() => {
+											cancelLoading = true;
+										});
+										return async ({ update }) => {
+											try {
+												await update();
+											} finally {
+												flushSync(() => {
+													cancelLoading = false;
+												});
+											}
+										};
+									}}
+								>
+									<input type="hidden" name="qrId" value={qrId} />
+									<Button type="submit" loading={cancelLoading} variant="destructive">
+										{m.cancel_confirm_yes()}
+									</Button>
+								</form>
+							</Dialog.DialogFooter>
+						</Dialog.DialogContent>
+					</Dialog.Dialog>
 				</div>
 			{/if}
 		</div>


### PR DESCRIPTION
## Summary

- Removes the immediate-cancel X button from pending transaction rows on the home and history screens — the row is already a tappable link to the detail view, so the X was redundant and dangerous (single misclick permanently invalidated a QR)
- Replaces it with a `ChevronRightIcon` on non-expired items as a visual affordance for "tap to view details"; expired items show nothing
- Adds a confirmation dialog on the send/receive QR screens before cancelling, using the existing (but previously unused) `Dialog` components
- Removes the now-dead `cancelQr` server actions from home and history
- Adds `cancel_confirm_*` i18n keys in all 4 languages (EN, NL, DE, PT); removes unused `pending_cancel_aria`

## Test plan

- [ ] Home screen: pending items show chevron, tapping navigates to send/receive detail view
- [ ] Home screen: expired items show no chevron and are non-clickable
- [ ] History "Pending" tab: same chevron behaviour
- [ ] Send QR screen: "Cancel" button opens confirmation dialog; "Keep waiting" dismisses; "Yes, cancel" invalidates the QR and redirects home
- [ ] Receive QR screen: same dialog behaviour
- [ ] `bun run check` — 0 errors
- [ ] `bun run test` — 158 tests passing
- [ ] `bunx playwright test` — E2E suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)