### PR TITLE
fix: guard (app)/ routes in hooks.server.ts to prevent null appUser crashes

### DIFF
--- a/e2e/auth-guard.test.ts
+++ b/e2e/auth-guard.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { test, expect, goto, deleteTestUser } from './test-utils.js';
+import { auth } from './auth.js';
+import type { TestHelpers } from 'better-auth/plugins';
+
+/**
+ * Regression tests for the auth guard on (app)/ routes.
+ *
+ * A user with a valid Better Auth session but NO app_users record (pre-onboarding
+ * state) must be redirected to /onboarding/intro1 rather than crashing with
+ * "TypeError: null is not an object".
+ */
+
+async function createSessionCookies(
+	userId: string
+): Promise<Awaited<ReturnType<TestHelpers['getCookies']>>> {
+	const ctx = await auth.$context;
+	const testUtils = (ctx as { test: TestHelpers }).test;
+	return testUtils.getCookies({ userId, domain: 'localhost' });
+}
+
+async function createBetterAuthUserOnly(email: string, displayName: string): Promise<string> {
+	const ctx = await auth.$context;
+	const testUtils = (ctx as { test: TestHelpers }).test;
+	const user = testUtils.createUser({ email, emailVerified: true, name: displayName });
+	await testUtils.saveUser(user);
+	// Intentionally do NOT insert into app_users — this is the pre-onboarding state.
+	return user.id;
+}
+
+test.describe.serial('auth guard — session without appUser', () => {
+	test.afterEach(async ({ email }) => {
+		await deleteTestUser(email('user'));
+	});
+
+	test('redirects /home to /onboarding/intro1', async ({ page, context, email }) => {
+		const userId = await createBetterAuthUserOnly(email('user'), 'No AppUser');
+		const cookies = await createSessionCookies(userId);
+		await context.addCookies(cookies);
+
+		await goto(page, '/home');
+
+		await page.waitForURL(/\/onboarding\/intro1/, { timeout: 10_000 });
+		await expect(page).toHaveURL(/\/onboarding\/intro1/);
+	});
+
+	test('redirects /send to /onboarding/intro1', async ({ page, context, email }) => {
+		const userId = await createBetterAuthUserOnly(email('user'), 'No AppUser');
+		const cookies = await createSessionCookies(userId);
+		await context.addCookies(cookies);
+
+		await goto(page, '/send');
+
+		await page.waitForURL(/\/onboarding\/intro1/, { timeout: 10_000 });
+		await expect(page).toHaveURL(/\/onboarding\/intro1/);
+	});
+});

--- a/e2e/auth-guard.test.ts
+++ b/e2e/auth-guard.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { test, expect, goto, deleteTestUser } from './test-utils.js';
+import { test, expect, goto, deleteTestUser, getAuthCookies } from './test-utils.js';
 import { auth } from './auth.js';
 import type { TestHelpers } from 'better-auth/plugins';
 
@@ -10,14 +10,6 @@ import type { TestHelpers } from 'better-auth/plugins';
  * state) must be redirected to /onboarding/intro1 rather than crashing with
  * "TypeError: null is not an object".
  */
-
-async function createSessionCookies(
-	userId: string
-): Promise<Awaited<ReturnType<TestHelpers['getCookies']>>> {
-	const ctx = await auth.$context;
-	const testUtils = (ctx as { test: TestHelpers }).test;
-	return testUtils.getCookies({ userId, domain: 'localhost' });
-}
 
 async function createBetterAuthUserOnly(email: string, displayName: string): Promise<string> {
 	const ctx = await auth.$context;
@@ -35,7 +27,7 @@ test.describe.serial('auth guard — session without appUser', () => {
 
 	test('redirects /home to /onboarding/intro1', async ({ page, context, email }) => {
 		const userId = await createBetterAuthUserOnly(email('user'), 'No AppUser');
-		const cookies = await createSessionCookies(userId);
+		const cookies = await getAuthCookies(userId);
 		await context.addCookies(cookies);
 
 		await goto(page, '/home');
@@ -46,7 +38,7 @@ test.describe.serial('auth guard — session without appUser', () => {
 
 	test('redirects /send to /onboarding/intro1', async ({ page, context, email }) => {
 		const userId = await createBetterAuthUserOnly(email('user'), 'No AppUser');
-		const cookies = await createSessionCookies(userId);
+		const cookies = await getAuthCookies(userId);
 		await context.addCookies(cookies);
 
 		await goto(page, '/send');

--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const REQUEST_STATE_ERROR =
 	'No request state found. Please make sure you are calling this function within a `runWithRequestState` callback.';
@@ -28,7 +28,16 @@ vi.mock('$lib/server/auth', () => ({
 }));
 
 vi.mock('$lib/server/db', () => ({
-	db: {},
+	db: {
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					// Default: no app_users row found
+					limit: () => Promise.resolve([])
+				})
+			})
+		})
+	},
 	sqlite: null
 }));
 
@@ -58,6 +67,71 @@ vi.mock('$app/environment', () => ({
 }));
 
 import { authHandle } from './hooks.server';
+
+beforeEach(() => vi.clearAllMocks());
+
+const mockSession = {
+	session: { id: 'sess1', userId: 'ba-user1', expiresAt: new Date() },
+	user: { id: 'ba-user1', email: 'test@example.com' }
+};
+
+function makeAppEvent(method: string) {
+	return {
+		event: {
+			url: new URL('https://example.test/home'),
+			request: new Request('https://example.test/home', { method }),
+			route: { id: '/(app)/home' },
+			locals: {}
+		},
+		resolve: vi.fn()
+	} as unknown as Parameters<typeof authHandle>[0];
+}
+
+describe('authHandle — (app)/ route guard redirect status', () => {
+	describe('session exists but no app_users row', () => {
+		test('GET redirects to /onboarding/intro1 with 307', async () => {
+			getSessionMock.mockResolvedValueOnce(mockSession);
+			await expect(authHandle(makeAppEvent('GET'))).rejects.toMatchObject({
+				status: 307,
+				location: '/onboarding/intro1'
+			});
+		});
+
+		test('HEAD redirects to /onboarding/intro1 with 307', async () => {
+			getSessionMock.mockResolvedValueOnce(mockSession);
+			await expect(authHandle(makeAppEvent('HEAD'))).rejects.toMatchObject({
+				status: 307,
+				location: '/onboarding/intro1'
+			});
+		});
+
+		test('POST redirects to /onboarding/intro1 with 303', async () => {
+			getSessionMock.mockResolvedValueOnce(mockSession);
+			await expect(authHandle(makeAppEvent('POST'))).rejects.toMatchObject({
+				status: 303,
+				location: '/onboarding/intro1'
+			});
+		});
+	});
+
+	describe('no session at all', () => {
+		test('GET redirects to /onboarding with 307', async () => {
+			getSessionMock.mockResolvedValueOnce(null);
+			await expect(authHandle(makeAppEvent('GET'))).rejects.toMatchObject({
+				status: 307,
+				location: '/onboarding'
+			});
+		});
+
+		test('POST redirects to /onboarding with 303', async () => {
+			getSessionMock.mockResolvedValueOnce(null);
+			await expect(authHandle(makeAppEvent('POST'))).rejects.toMatchObject({
+				status: 303,
+				location: '/onboarding'
+			});
+		});
+	});
+});
 
 describe('authHandle', () => {
 	test('regression: bypasses Better Auth session lookup for /sentry-tunnel', async () => {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -104,8 +104,12 @@ export const authHandle: Handle = async ({ event, resolve }) => {
 	// Layout guards are insufficient: page loads run in parallel with layouts,
 	// and form actions bypass layout load functions entirely.
 	if (event.route.id?.startsWith('/(app)')) {
-		if (!event.locals.session) redirect(307, '/onboarding');
-		if (!event.locals.appUser) redirect(307, '/onboarding/intro1');
+		// Use 303 for POST/PUT/etc. so the browser follows up with GET;
+		// 307 would forward the original method to the onboarding page.
+		const status =
+			event.request.method === 'GET' || event.request.method === 'HEAD' ? 307 : 303;
+		if (!event.locals.session) redirect(status, '/onboarding');
+		if (!event.locals.appUser) redirect(status, '/onboarding/intro1');
 	}
 
 	// svelteKitHandler replaces the manual auth.handler() + resolve() calls.

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,7 +5,7 @@ import { auth } from '$lib/server/auth';
 import { db, sqlite } from '$lib/server/db';
 import { appUsers } from '$lib/server/schema';
 import { eq } from 'drizzle-orm';
-import type { Handle, ServerInit } from '@sveltejs/kit';
+import { redirect, type Handle, type ServerInit } from '@sveltejs/kit';
 import { config } from '$lib/config';
 import { sequence } from '@sveltejs/kit/hooks';
 import { paraglideMiddleware } from '$lib/paraglide/server';
@@ -98,6 +98,14 @@ export const authHandle: Handle = async ({ event, resolve }) => {
 		event.locals.session = null;
 		event.locals.user = null;
 		event.locals.appUser = null;
+	}
+
+	// Guard (app) routes here — before load functions and actions run.
+	// Layout guards are insufficient: page loads run in parallel with layouts,
+	// and form actions bypass layout load functions entirely.
+	if (event.route.id?.startsWith('/(app)')) {
+		if (!event.locals.session) redirect(307, '/onboarding');
+		if (!event.locals.appUser) redirect(307, '/onboarding/intro1');
 	}
 
 	// svelteKitHandler replaces the manual auth.handler() + resolve() calls.

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -106,8 +106,7 @@ export const authHandle: Handle = async ({ event, resolve }) => {
 	if (event.route.id?.startsWith('/(app)')) {
 		// Use 303 for POST/PUT/etc. so the browser follows up with GET;
 		// 307 would forward the original method to the onboarding page.
-		const status =
-			event.request.method === 'GET' || event.request.method === 'HEAD' ? 307 : 303;
+		const status = event.request.method === 'GET' || event.request.method === 'HEAD' ? 307 : 303;
 		if (!event.locals.session) redirect(status, '/onboarding');
 		if (!event.locals.appUser) redirect(status, '/onboarding/intro1');
 	}

--- a/src/routes/accept/[token]/+page.server.ts
+++ b/src/routes/accept/[token]/+page.server.ts
@@ -45,9 +45,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		return { expired: true, error: 'Initiator not found.' };
 	}
 
-	const needsAuth = !locals.session || !locals.appUser;
-
-	if (needsAuth) {
+	if (!locals.session || !locals.appUser) {
 		// Return enough info to show the transaction preview. qrId is included only for the
 		// Decline action; the Accept action enforces auth server-side and is not rendered here.
 		// The startFastTrack / startFullOnboarding actions handle the auth redirect.
@@ -64,8 +62,8 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		};
 	}
 
-	// Prevent self-acceptance (appUser is non-null here: needsAuth guard above returned early)
-	if (locals.appUser!.id === qr.initiatingUserId) {
+	// Prevent self-acceptance (locals.appUser is narrowed to non-null by the check above)
+	if (locals.appUser.id === qr.initiatingUserId) {
 		return {
 			expired: true,
 			error: 'You cannot accept your own QR code.'


### PR DESCRIPTION
## Summary

- Adds auth guard for `(app)/` routes directly in `authHandle` (hooks.server.ts), which runs **before** all load functions and form actions
- Inlines the `needsAuth` boolean check in `accept/[token]/+page.server.ts` so TypeScript can narrow `locals.appUser` without the `!` assertion
- Adds E2E regression tests verifying that a user with a session but no `app_users` row is redirected to `/onboarding/intro1`

Closes #99, closes #100.

## Root cause

SvelteKit runs layout and page `load` functions **in parallel**, so the redirect in `(app)/+layout.server.ts` does not prevent the page load from executing when `appUser` is null — both run concurrently and the page crashes before the layout redirect takes effect. Form actions bypass layout loads entirely, leaving them unguarded.

The fix puts the check in `hooks.server.ts`, which is the [SvelteKit-recommended place](https://lucia-auth.com/sessions/frameworks/sveltekit) for route protection: the `handle` function runs before all load functions and actions.

## Test plan

- [x] `bun run check` — 0 type errors
- [x] `bun run test` — 158 unit tests pass
- [x] New E2E regression tests in `e2e/auth-guard.test.ts` pass (2/2)
- [x] Full `bunx playwright test` suite passes (1 pre-existing flaky failure in `faq.test.ts` unrelated to this change, passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)