### PR TITLE
feat: add what's new dialog shown once per version update

### DIFF
--- a/drizzle/pg/0003_new_white_tiger.sql
+++ b/drizzle/pg/0003_new_white_tiger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "app_users" ADD COLUMN "last_seen_version" text DEFAULT '0.1.0';

--- a/drizzle/pg/meta/0003_snapshot.json
+++ b/drizzle/pg/meta/0003_snapshot.json
@@ -1,0 +1,680 @@
+{
+	"id": "27560c2b-de22-4875-abd5-b10ad853111c",
+	"prevId": "a4b2f1af-99a5-49fa-ad2c-e500dca362b9",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_users": {
+			"name": "app_users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"better_auth_user_id": {
+					"name": "better_auth_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"send_consent_at": {
+					"name": "send_consent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_seen_version": {
+					"name": "last_seen_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_users_better_auth_user_id_user_id_fk": {
+					"name": "app_users_better_auth_user_id_user_id_fk",
+					"tableFrom": "app_users",
+					"tableTo": "user",
+					"columnsFrom": ["better_auth_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"app_users_better_auth_user_id_unique": {
+					"name": "app_users_better_auth_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["better_auth_user_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.connections": {
+			"name": "connections",
+			"schema": "",
+			"columns": {
+				"user_a_id": {
+					"name": "user_a_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_b_id": {
+					"name": "user_b_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"connections_user_a_id_app_users_id_fk": {
+					"name": "connections_user_a_id_app_users_id_fk",
+					"tableFrom": "connections",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_a_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"connections_user_b_id_app_users_id_fk": {
+					"name": "connections_user_b_id_app_users_id_fk",
+					"tableFrom": "connections",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_b_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"connections_user_a_id_user_b_id_pk": {
+					"name": "connections_user_a_id_user_b_id_pk",
+					"columns": ["user_a_id", "user_b_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.pending_qr": {
+			"name": "pending_qr",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"initiating_user_id": {
+					"name": "initiating_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"direction": {
+					"name": "direction",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount": {
+					"name": "amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"pending_qr_initiating_user_id_app_users_id_fk": {
+					"name": "pending_qr_initiating_user_id_app_users_id_fk",
+					"tableFrom": "pending_qr",
+					"tableTo": "app_users",
+					"columnsFrom": ["initiating_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.push_subscriptions": {
+			"name": "push_subscriptions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"p256dh": {
+					"name": "p256dh",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"auth": {
+					"name": "auth",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"push_subscriptions_user_endpoint_idx": {
+					"name": "push_subscriptions_user_endpoint_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"push_subscriptions_user_id_app_users_id_fk": {
+					"name": "push_subscriptions_user_id_app_users_id_fk",
+					"tableFrom": "push_subscriptions",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.transactions": {
+			"name": "transactions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"from_user_id": {
+					"name": "from_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"to_user_id": {
+					"name": "to_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount": {
+					"name": "amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"unit_code": {
+					"name": "unit_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pending_qr_id": {
+					"name": "pending_qr_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"transactions_from_user_id_app_users_id_fk": {
+					"name": "transactions_from_user_id_app_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "app_users",
+					"columnsFrom": ["from_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_to_user_id_app_users_id_fk": {
+					"name": "transactions_to_user_id_app_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "app_users",
+					"columnsFrom": ["to_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_pending_qr_id_pending_qr_id_fk": {
+					"name": "transactions_pending_qr_id_pending_qr_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "pending_qr",
+					"columnsFrom": ["pending_qr_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phone_number": {
+					"name": "phone_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone_number_verified": {
+					"name": "phone_number_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/pg/meta/_journal.json
+++ b/drizzle/pg/meta/_journal.json
@@ -22,6 +22,13 @@
 			"when": 1776164754185,
 			"tag": "0002_fix_null_placeholder_emails",
 			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1776351616340,
+			"tag": "0003_new_white_tiger",
+			"breakpoints": true
 		}
 	]
 }

--- a/drizzle/sqlite/0004_organic_ezekiel.sql
+++ b/drizzle/sqlite/0004_organic_ezekiel.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `app_users` ADD `last_seen_version` text DEFAULT '0.1.0';

--- a/drizzle/sqlite/meta/0004_snapshot.json
+++ b/drizzle/sqlite/meta/0004_snapshot.json
@@ -1,0 +1,704 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "bda1249e-1d56-430e-b1de-17f40bda3c10",
+	"prevId": "1c384ff5-2747-4b8c-924d-04b268e80042",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"app_users": {
+			"name": "app_users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"better_auth_user_id": {
+					"name": "better_auth_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"send_consent_at": {
+					"name": "send_consent_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_seen_version": {
+					"name": "last_seen_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"app_users_better_auth_user_id_unique": {
+					"name": "app_users_better_auth_user_id_unique",
+					"columns": ["better_auth_user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"app_users_better_auth_user_id_user_id_fk": {
+					"name": "app_users_better_auth_user_id_user_id_fk",
+					"tableFrom": "app_users",
+					"tableTo": "user",
+					"columnsFrom": ["better_auth_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"connections": {
+			"name": "connections",
+			"columns": {
+				"user_a_id": {
+					"name": "user_a_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_b_id": {
+					"name": "user_b_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"connections_user_a_id_app_users_id_fk": {
+					"name": "connections_user_a_id_app_users_id_fk",
+					"tableFrom": "connections",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_a_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"connections_user_b_id_app_users_id_fk": {
+					"name": "connections_user_b_id_app_users_id_fk",
+					"tableFrom": "connections",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_b_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"connections_user_a_id_user_b_id_pk": {
+					"columns": ["user_a_id", "user_b_id"],
+					"name": "connections_user_a_id_user_b_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"pending_qr": {
+			"name": "pending_qr",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"initiating_user_id": {
+					"name": "initiating_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"direction": {
+					"name": "direction",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"pending_qr_initiating_user_id_app_users_id_fk": {
+					"name": "pending_qr_initiating_user_id_app_users_id_fk",
+					"tableFrom": "pending_qr",
+					"tableTo": "app_users",
+					"columnsFrom": ["initiating_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"push_subscriptions": {
+			"name": "push_subscriptions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"p256dh": {
+					"name": "p256dh",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"auth": {
+					"name": "auth",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"push_subscriptions_user_endpoint_idx": {
+					"name": "push_subscriptions_user_endpoint_idx",
+					"columns": ["user_id", "endpoint"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"push_subscriptions_user_id_app_users_id_fk": {
+					"name": "push_subscriptions_user_id_app_users_id_fk",
+					"tableFrom": "push_subscriptions",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"transactions": {
+			"name": "transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"from_user_id": {
+					"name": "from_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"to_user_id": {
+					"name": "to_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"unit_code": {
+					"name": "unit_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pending_qr_id": {
+					"name": "pending_qr_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"transactions_from_user_id_app_users_id_fk": {
+					"name": "transactions_from_user_id_app_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "app_users",
+					"columnsFrom": ["from_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_to_user_id_app_users_id_fk": {
+					"name": "transactions_to_user_id_app_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "app_users",
+					"columnsFrom": ["to_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_pending_qr_id_pending_qr_id_fk": {
+					"name": "transactions_pending_qr_id_pending_qr_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "pending_qr",
+					"columnsFrom": ["pending_qr_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"phone_number": {
+					"name": "phone_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phone_number_verified": {
+					"name": "phone_number_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/sqlite/meta/_journal.json
+++ b/drizzle/sqlite/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1776164747573,
 			"tag": "0003_fix_null_placeholder_emails",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1776351613578,
+			"tag": "0004_organic_ezekiel",
+			"breakpoints": true
 		}
 	]
 }

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -5,6 +5,7 @@ import type { TestHelpers } from 'better-auth/plugins';
 import * as jose from 'jose';
 import { auth, sqlite } from './auth.js';
 import { E2E_BASE_URL, E2E_QR_JWT_SECRET } from './config.js';
+import pkg from '../package.json' with { type: 'json' };
 
 export { expect } from '@playwright/test';
 
@@ -129,10 +130,10 @@ export async function createTestUser(email: string, displayName: string): Promis
 	const now = Math.floor(Date.now() / 1000);
 	sqlite
 		.prepare(
-			`INSERT INTO app_users (id, better_auth_user_id, display_name, created_at)
-			 VALUES (?, ?, ?, ?)`
+			`INSERT INTO app_users (id, better_auth_user_id, display_name, created_at, last_seen_version)
+			 VALUES (?, ?, ?, ?, ?)`
 		)
-		.run(id, user.id, displayName, now);
+		.run(id, user.id, displayName, now, pkg.version);
 
 	return user.id;
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -250,5 +250,9 @@
 	"install_banner_not_now": "Nicht jetzt",
 
 	"toast_transaction_accepted": "{name} — {amount}",
-	"toast_transaction_declined": "Deine Anfrage wurde abgelehnt"
+	"toast_transaction_declined": "Deine Anfrage wurde abgelehnt",
+	"whats_new_title": "Was ist neu",
+	"whats_new_dismiss": "Verstanden",
+	"whats_new_version_label": "Version {version}",
+	"whats_new_v0_2_0": "E-Mail und Telefonnummer in den Einstellungen verwalten\nSpanische Sprachunterstützung\nVerbesserte Navigation mit Zurück-Schaltfläche und Abbruchbestätigung"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -263,5 +263,9 @@
 	"install_banner_not_now": "Not now",
 
 	"toast_transaction_accepted": "{name} — {amount}",
-	"toast_transaction_declined": "Your request was declined"
+	"toast_transaction_declined": "Your request was declined",
+	"whats_new_title": "What's new",
+	"whats_new_dismiss": "Got it",
+	"whats_new_version_label": "Version {version}",
+	"whats_new_v0_2_0": "Manage your email and phone number in settings\nSpanish language support\nImproved navigation with back button and cancel confirmation"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -262,5 +262,9 @@
 	"install_banner_not_now": "Ahora no",
 
 	"toast_transaction_accepted": "{name} — {amount}",
-	"toast_transaction_declined": "Tu solicitud fue rechazada"
+	"toast_transaction_declined": "Tu solicitud fue rechazada",
+	"whats_new_title": "Novedades",
+	"whats_new_dismiss": "Entendido",
+	"whats_new_version_label": "Versión {version}",
+	"whats_new_v0_2_0": "Gestiona tu correo electrónico y número de teléfono en la configuración\nSoporte para el idioma español\nNavegación mejorada con botón de retroceso y confirmación de cancelación"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -262,5 +262,9 @@
 	"install_banner_not_now": "Niet nu",
 
 	"toast_transaction_accepted": "{name} — {amount}",
-	"toast_transaction_declined": "Jouw verzoek is afgewezen"
+	"toast_transaction_declined": "Jouw verzoek is afgewezen",
+	"whats_new_title": "Wat is er nieuw",
+	"whats_new_dismiss": "Begrepen",
+	"whats_new_version_label": "Versie {version}",
+	"whats_new_v0_2_0": "Beheer uw e-mail en telefoonnummer in instellingen\nSpaanse taalondersteuning\nVerbeterde navigatie met terugknop en annuleringsbevestiging"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -262,5 +262,9 @@
 	"install_banner_not_now": "Agora não",
 
 	"toast_transaction_accepted": "{name} — {amount}",
-	"toast_transaction_declined": "O teu pedido foi recusado"
+	"toast_transaction_declined": "O teu pedido foi recusado",
+	"whats_new_title": "O que há de novo",
+	"whats_new_dismiss": "Entendi",
+	"whats_new_version_label": "Versão {version}",
+	"whats_new_v0_2_0": "Gerencie seu e-mail e número de telefone nas configurações\nSuporte ao idioma espanhol\nNavegação melhorada com botão de voltar e confirmação de cancelamento"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mutuvia",
 	"private": true,
-	"version": "0.0.1",
+	"version": "0.2.0",
 	"type": "module",
 	"scripts": {
 		"dev": "bun --bun vite dev",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -17,6 +17,7 @@ declare global {
 				displayName: string;
 				sendConsentAt: Date | null;
 				createdAt: Date;
+				lastSeenVersion: string | null;
 			} | null;
 		}
 		// interface PageData {}
@@ -31,6 +32,8 @@ declare global {
 	interface WindowEventMap {
 		beforeinstallprompt: BeforeInstallPromptEvent;
 	}
+
+	declare const __APP_VERSION__: string;
 }
 
 export {};

--- a/src/lib/components/whats-new-dialog.svelte
+++ b/src/lib/components/whats-new-dialog.svelte
@@ -1,0 +1,68 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+	import { browser } from '$app/environment';
+	import { Button } from '$lib/components/ui/button';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { getUnseenEntries } from '$lib/whats-new';
+	import SparklesIcon from '@lucide/svelte/icons/sparkles';
+
+	interface Props {
+		appVersion: string;
+		lastSeenVersion: string | null;
+	}
+
+	let { appVersion, lastSeenVersion }: Props = $props();
+
+	const unseenEntries = browser ? getUnseenEntries(lastSeenVersion) : [];
+	let open = $state(unseenEntries.length > 0);
+
+	async function dismiss() {
+		if (!open) return;
+		open = false;
+		try {
+			await fetch('/api/whats-new/dismiss', { method: 'POST' });
+		} catch {
+			// Silent fail — user will see dialog again next visit
+		}
+	}
+</script>
+
+<Dialog.Root
+	{open}
+	onOpenChange={(v) => {
+		if (!v) dismiss();
+	}}
+>
+	<Dialog.Content showCloseButton={false}>
+		<Dialog.Header>
+			<div class="flex items-center gap-3">
+				<div
+					class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[#2D4A32] text-white"
+				>
+					<SparklesIcon class="h-5 w-5" />
+				</div>
+				<div class="min-w-0 flex-1">
+					<Dialog.Title class="text-sm">{m.whats_new_title()}</Dialog.Title>
+					<Dialog.Description class="text-xs">
+						{m.whats_new_version_label({ version: appVersion })}
+					</Dialog.Description>
+				</div>
+			</div>
+		</Dialog.Header>
+
+		<div class="max-h-60 space-y-4 overflow-y-auto">
+			{#each unseenEntries as entry (entry.version)}
+				<ul class="list-inside list-disc space-y-1 text-sm">
+					{#each entry.content().split('\n') as item (item)}
+						<li>{item}</li>
+					{/each}
+				</ul>
+			{/each}
+		</div>
+
+		<Dialog.Footer>
+			<Button onclick={dismiss}>{m.whats_new_dismiss()}</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -88,5 +88,8 @@ export const config = {
 	},
 	get vapidSubject() {
 		return env.VAPID_SUBJECT ?? `mailto:admin@example.com`;
+	},
+	get appVersion(): string {
+		return __APP_VERSION__;
 	}
 };

--- a/src/lib/server/schema.pg.ts
+++ b/src/lib/server/schema.pg.ts
@@ -75,7 +75,8 @@ export const appUsers = pgTable('app_users', {
 		.references(() => user.id),
 	displayName: text('display_name').notNull(),
 	sendConsentAt: timestamp('send_consent_at'),
-	createdAt: timestamp('created_at').notNull()
+	createdAt: timestamp('created_at').notNull(),
+	lastSeenVersion: text('last_seen_version')
 });
 
 export const transactions = pgTable('transactions', {

--- a/src/lib/server/schema.sqlite.ts
+++ b/src/lib/server/schema.sqlite.ts
@@ -67,7 +67,8 @@ export const appUsers = sqliteTable('app_users', {
 		.references(() => user.id),
 	displayName: text('display_name').notNull(),
 	sendConsentAt: integer('send_consent_at', { mode: 'timestamp' }),
-	createdAt: integer('created_at', { mode: 'timestamp' }).notNull()
+	createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+	lastSeenVersion: text('last_seen_version')
 });
 
 export const transactions = sqliteTable('transactions', {

--- a/src/lib/whats-new.test.ts
+++ b/src/lib/whats-new.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, test, expect, vi } from 'vitest';
+
+vi.mock('$lib/paraglide/messages.js', () => ({
+	whats_new_v0_2_0: () => 'Feature A\nFeature B'
+}));
+
+const { getUnseenEntries, changelog } = await import('./whats-new.js');
+
+describe('getUnseenEntries', () => {
+	describe('when lastSeenVersion is null', () => {
+		test('returns all changelog entries', () => {
+			const result = getUnseenEntries(null);
+			expect(result).toEqual(changelog);
+		});
+	});
+
+	describe('when lastSeenVersion matches the current version', () => {
+		test('returns no entries', () => {
+			const result = getUnseenEntries('0.2.0');
+			expect(result).toHaveLength(0);
+		});
+	});
+
+	describe('when lastSeenVersion is not found in the changelog', () => {
+		test('returns all entries for an old version', () => {
+			const result = getUnseenEntries('0.1.0');
+			expect(result).toEqual(changelog);
+		});
+
+		test('returns all entries for an unrecognised version string', () => {
+			const result = getUnseenEntries('0.0.1');
+			expect(result).toEqual(changelog);
+		});
+	});
+});

--- a/src/lib/whats-new.test.ts
+++ b/src/lib/whats-new.test.ts
@@ -34,4 +34,23 @@ describe('getUnseenEntries', () => {
 			expect(result).toEqual(changelog);
 		});
 	});
+
+	describe('when there are multiple changelog entries', () => {
+		const v1 = { version: '0.3.0', content: () => 'C' };
+		const v2 = { version: '0.2.0', content: () => 'B' };
+		const v3 = { version: '0.1.0', content: () => 'A' };
+		const entries = [v1, v2, v3];
+
+		test('returns only entries newer than lastSeenVersion', () => {
+			expect(getUnseenEntries('0.2.0', entries)).toEqual([v1]);
+		});
+
+		test('returns all entries when version predates the changelog', () => {
+			expect(getUnseenEntries('0.0.1', entries)).toEqual(entries);
+		});
+
+		test('returns no entries when already on the latest version', () => {
+			expect(getUnseenEntries('0.3.0', entries)).toHaveLength(0);
+		});
+	});
 });

--- a/src/lib/whats-new.ts
+++ b/src/lib/whats-new.ts
@@ -19,9 +19,12 @@ export interface WhatsNewEntry {
 export const changelog: WhatsNewEntry[] = [{ version: '0.2.0', content: m.whats_new_v0_2_0 }];
 
 /** Returns changelog entries the user has not yet seen. */
-export function getUnseenEntries(lastSeenVersion: string | null): WhatsNewEntry[] {
-	if (lastSeenVersion === null) return changelog;
-	const idx = changelog.findIndex((e) => e.version === lastSeenVersion);
-	if (idx === -1) return changelog;
-	return changelog.slice(0, idx);
+export function getUnseenEntries(
+	lastSeenVersion: string | null,
+	entries: WhatsNewEntry[] = changelog
+): WhatsNewEntry[] {
+	if (lastSeenVersion === null) return entries;
+	const idx = entries.findIndex((e) => e.version === lastSeenVersion);
+	if (idx === -1) return entries;
+	return entries.slice(0, idx);
 }

--- a/src/lib/whats-new.ts
+++ b/src/lib/whats-new.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as m from '$lib/paraglide/messages.js';
+
+export interface WhatsNewEntry {
+	version: string;
+	content: () => string;
+}
+
+/**
+ * Changelog entries ordered newest-first.
+ *
+ * To add a new release:
+ * 1. Add message keys to all locale files in messages/*.json
+ *    (whats_new_vX_Y_Z with \n-delimited bullet points)
+ * 2. Add an entry here at the top of the array
+ * 3. Bump version in package.json
+ */
+export const changelog: WhatsNewEntry[] = [{ version: '0.2.0', content: m.whats_new_v0_2_0 }];
+
+/** Returns changelog entries the user has not yet seen. */
+export function getUnseenEntries(lastSeenVersion: string | null): WhatsNewEntry[] {
+	if (lastSeenVersion === null) return changelog;
+	const idx = changelog.findIndex((e) => e.version === lastSeenVersion);
+	if (idx === -1) return changelog;
+	return changelog.slice(0, idx);
+}

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
+import { config } from '$lib/config';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
 	if (!locals.session) {
@@ -12,6 +13,7 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 	}
 
 	return {
-		appUser: locals.appUser
+		appUser: locals.appUser,
+		appVersion: config.appVersion
 	};
 };

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import InstallBanner from '$lib/components/install-banner.svelte';
+	import WhatsNewDialog from '$lib/components/whats-new-dialog.svelte';
 	import { onMount } from 'svelte';
 	import { sseManager } from '$lib/sse-client';
 	import { toast } from 'svelte-sonner';
 	import { page } from '$app/state';
 	import * as m from '$lib/paraglide/messages.js';
 
-	let { children } = $props();
+	let { children, data } = $props();
 
 	onMount(() => {
 		sseManager.connect();
@@ -37,3 +38,7 @@
 </div>
 
 <InstallBanner />
+<WhatsNewDialog
+	appVersion={data.appVersion}
+	lastSeenVersion={data.appUser?.lastSeenVersion ?? null}
+/>

--- a/src/routes/(app)/layout.svelte.test.ts
+++ b/src/routes/(app)/layout.svelte.test.ts
@@ -44,6 +44,10 @@ vi.mock('$lib/paraglide/messages.js', () => ({
 vi.mock('$lib/paraglide/runtime.js', () => ({ getLocale: () => 'en' }));
 
 vi.mock('$lib/components/install-banner.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/whats-new-dialog.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/whats-new', () => ({
+	getUnseenEntries: () => []
+}));
 
 vi.mock('$app/environment', () => ({ browser: true }));
 

--- a/src/routes/(app)/layout.svelte.test.ts
+++ b/src/routes/(app)/layout.svelte.test.ts
@@ -83,8 +83,10 @@ describe('(app) layout – SSE → toast handlers', () => {
 			render: () => '<div></div>',
 			setup: () => {}
 		}));
+
+		const data = { appVersion: '0.2.0', appUser: null };
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		return render(AppLayout, { props: { children } as any });
+		return render(AppLayout, { props: { children, data } as any });
 	}
 
 	it('connects SSE manager on mount', () => {

--- a/src/routes/api/whats-new/dismiss/+server.ts
+++ b/src/routes/api/whats-new/dismiss/+server.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { RequestHandler } from './$types';
+import { db } from '$lib/server/db';
+import { appUsers } from '$lib/server/schema';
+import { eq } from 'drizzle-orm';
+import { config } from '$lib/config';
+
+export const POST: RequestHandler = async ({ locals }) => {
+	if (!locals.appUser) {
+		return new Response(null, { status: 401 });
+	}
+
+	await db
+		.update(appUsers)
+		.set({ lastSeenVersion: config.appVersion })
+		.where(eq(appUsers.id, locals.appUser.id));
+
+	return new Response(null, { status: 204 });
+};

--- a/src/routes/onboarding/name/+page.server.ts
+++ b/src/routes/onboarding/name/+page.server.ts
@@ -7,6 +7,7 @@ import { eq } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import type { Cookies } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
+import { config } from '$lib/config';
 
 function consumeQrReturnTo(cookies: Cookies): string | null {
 	const returnTo = cookies.get('qr_return_to');
@@ -57,6 +58,7 @@ export const actions: Actions = {
 			id: randomUUID(),
 			betterAuthUserId: locals.user.id,
 			displayName,
+			lastSeenVersion: config.appVersion,
 			createdAt: new Date()
 		});
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,8 @@ import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import type { ViteDevServer } from 'vite';
 
+const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as { version: string };
+
 function hashFile(path: string): string {
 	return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
@@ -30,6 +32,9 @@ const devUrlPlugin = {
 };
 
 export default defineConfig({
+	define: {
+		__APP_VERSION__: JSON.stringify(pkg.version)
+	},
 	plugins: [
 		devUrlPlugin,
 		paraglideVitePlugin({


### PR DESCRIPTION
## Summary

- Adds a \"What's new\" dialog that shows automatically on app startup after a version update
- Skips for new installs (version seeded at profile creation) and repeat visits (tracked server-side in `appUsers.last_seen_version`)
- Ships v0.2.0 with changelog: credential management in settings, Spanish language support, improved navigation

## Implementation

- `appUsers.last_seen_version` column (both SQLite + PG migrations) — migration defaults existing users to `0.1.0` so they see the v0.2.0 dialog
- `__APP_VERSION__` injected at build time from `package.json` via Vite `define`; accessed via `config.appVersion`
- Changelog data in `src/lib/whats-new.ts` with per-version Paraglide message keys (`whats_new_vX_Y_Z`, `\n`-delimited bullets)
- `POST /api/whats-new/dismiss` marks the current version as seen
- Dialog follows the `install-banner.svelte` pattern; guarded against double-POST on close

## Test plan

- [ ] Unit tests pass (`bun run test`) — `getUnseenEntries()` covered for all edge cases
- [ ] Type-check passes (`bun run check`)
- [ ] New user: complete onboarding → no dialog on first app load
- [ ] Existing user (simulated by `last_seen_version = '0.1.0'`): dialog appears on home screen, shows 3 v0.2.0 bullets
- [ ] Dismiss dialog → does not reappear on reload
- [ ] All 5 locales show translated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)