### PR TITLE
refactor(qr): replace JWT tokens with short UUIDs in QR URLs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,6 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-svelte": "^3.14.0",
         "globals": "^17.3.0",
-        "jose": "^6.2.2",
         "jsdom": "^29.0.1",
         "jsrepo": "^3.7.0",
         "mode-watcher": "^1.1.0",

--- a/drizzle/pg/0004_round_payback.sql
+++ b/drizzle/pg/0004_round_payback.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pending_qr" ADD COLUMN "initiator_name" text NOT NULL;

--- a/drizzle/pg/0004_round_payback.sql
+++ b/drizzle/pg/0004_round_payback.sql
@@ -1,1 +1,2 @@
-ALTER TABLE "pending_qr" ADD COLUMN "initiator_name" text NOT NULL;
+ALTER TABLE "pending_qr" ADD COLUMN "initiator_name" text NOT NULL DEFAULT '';
+ALTER TABLE "pending_qr" ALTER COLUMN "initiator_name" DROP DEFAULT;

--- a/drizzle/pg/meta/0004_snapshot.json
+++ b/drizzle/pg/meta/0004_snapshot.json
@@ -1,0 +1,686 @@
+{
+	"id": "424ce631-731f-48aa-bc0f-e5f6580abf36",
+	"prevId": "27560c2b-de22-4875-abd5-b10ad853111c",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_users": {
+			"name": "app_users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"better_auth_user_id": {
+					"name": "better_auth_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"send_consent_at": {
+					"name": "send_consent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_seen_version": {
+					"name": "last_seen_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_users_better_auth_user_id_user_id_fk": {
+					"name": "app_users_better_auth_user_id_user_id_fk",
+					"tableFrom": "app_users",
+					"tableTo": "user",
+					"columnsFrom": ["better_auth_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"app_users_better_auth_user_id_unique": {
+					"name": "app_users_better_auth_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["better_auth_user_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.connections": {
+			"name": "connections",
+			"schema": "",
+			"columns": {
+				"user_a_id": {
+					"name": "user_a_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_b_id": {
+					"name": "user_b_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"connections_user_a_id_app_users_id_fk": {
+					"name": "connections_user_a_id_app_users_id_fk",
+					"tableFrom": "connections",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_a_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"connections_user_b_id_app_users_id_fk": {
+					"name": "connections_user_b_id_app_users_id_fk",
+					"tableFrom": "connections",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_b_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"connections_user_a_id_user_b_id_pk": {
+					"name": "connections_user_a_id_user_b_id_pk",
+					"columns": ["user_a_id", "user_b_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.pending_qr": {
+			"name": "pending_qr",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"initiating_user_id": {
+					"name": "initiating_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"direction": {
+					"name": "direction",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount": {
+					"name": "amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"initiator_name": {
+					"name": "initiator_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"pending_qr_initiating_user_id_app_users_id_fk": {
+					"name": "pending_qr_initiating_user_id_app_users_id_fk",
+					"tableFrom": "pending_qr",
+					"tableTo": "app_users",
+					"columnsFrom": ["initiating_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.push_subscriptions": {
+			"name": "push_subscriptions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"p256dh": {
+					"name": "p256dh",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"auth": {
+					"name": "auth",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"push_subscriptions_user_endpoint_idx": {
+					"name": "push_subscriptions_user_endpoint_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"push_subscriptions_user_id_app_users_id_fk": {
+					"name": "push_subscriptions_user_id_app_users_id_fk",
+					"tableFrom": "push_subscriptions",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.transactions": {
+			"name": "transactions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"from_user_id": {
+					"name": "from_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"to_user_id": {
+					"name": "to_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount": {
+					"name": "amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"unit_code": {
+					"name": "unit_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pending_qr_id": {
+					"name": "pending_qr_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"transactions_from_user_id_app_users_id_fk": {
+					"name": "transactions_from_user_id_app_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "app_users",
+					"columnsFrom": ["from_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_to_user_id_app_users_id_fk": {
+					"name": "transactions_to_user_id_app_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "app_users",
+					"columnsFrom": ["to_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_pending_qr_id_pending_qr_id_fk": {
+					"name": "transactions_pending_qr_id_pending_qr_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "pending_qr",
+					"columnsFrom": ["pending_qr_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phone_number": {
+					"name": "phone_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone_number_verified": {
+					"name": "phone_number_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/pg/meta/_journal.json
+++ b/drizzle/pg/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1776351616340,
 			"tag": "0003_new_white_tiger",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1779973556271,
+			"tag": "0004_round_payback",
+			"breakpoints": true
 		}
 	]
 }

--- a/drizzle/sqlite/0005_boring_justice.sql
+++ b/drizzle/sqlite/0005_boring_justice.sql
@@ -1,1 +1,5 @@
+-- DEFAULT '' is a migration-only safety net for any existing rows.
+-- SQLite does not support ALTER COLUMN ... DROP DEFAULT, so the DB-level default
+-- remains, but the Drizzle schema (notNull, no .$defaultFn) ensures all
+-- application inserts supply this value explicitly.
 ALTER TABLE `pending_qr` ADD `initiator_name` text NOT NULL DEFAULT '';

--- a/drizzle/sqlite/0005_boring_justice.sql
+++ b/drizzle/sqlite/0005_boring_justice.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pending_qr` ADD `initiator_name` text NOT NULL;

--- a/drizzle/sqlite/0005_boring_justice.sql
+++ b/drizzle/sqlite/0005_boring_justice.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `pending_qr` ADD `initiator_name` text NOT NULL;
+ALTER TABLE `pending_qr` ADD `initiator_name` text NOT NULL DEFAULT '';

--- a/drizzle/sqlite/meta/0005_snapshot.json
+++ b/drizzle/sqlite/meta/0005_snapshot.json
@@ -1,0 +1,711 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "f045216d-d94f-491b-a5b0-c9071eeca9fa",
+	"prevId": "bda1249e-1d56-430e-b1de-17f40bda3c10",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"app_users": {
+			"name": "app_users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"better_auth_user_id": {
+					"name": "better_auth_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"send_consent_at": {
+					"name": "send_consent_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_seen_version": {
+					"name": "last_seen_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"app_users_better_auth_user_id_unique": {
+					"name": "app_users_better_auth_user_id_unique",
+					"columns": ["better_auth_user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"app_users_better_auth_user_id_user_id_fk": {
+					"name": "app_users_better_auth_user_id_user_id_fk",
+					"tableFrom": "app_users",
+					"tableTo": "user",
+					"columnsFrom": ["better_auth_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"connections": {
+			"name": "connections",
+			"columns": {
+				"user_a_id": {
+					"name": "user_a_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_b_id": {
+					"name": "user_b_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"connections_user_a_id_app_users_id_fk": {
+					"name": "connections_user_a_id_app_users_id_fk",
+					"tableFrom": "connections",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_a_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"connections_user_b_id_app_users_id_fk": {
+					"name": "connections_user_b_id_app_users_id_fk",
+					"tableFrom": "connections",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_b_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"connections_user_a_id_user_b_id_pk": {
+					"columns": ["user_a_id", "user_b_id"],
+					"name": "connections_user_a_id_user_b_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"pending_qr": {
+			"name": "pending_qr",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"initiating_user_id": {
+					"name": "initiating_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"direction": {
+					"name": "direction",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"initiator_name": {
+					"name": "initiator_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"pending_qr_initiating_user_id_app_users_id_fk": {
+					"name": "pending_qr_initiating_user_id_app_users_id_fk",
+					"tableFrom": "pending_qr",
+					"tableTo": "app_users",
+					"columnsFrom": ["initiating_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"push_subscriptions": {
+			"name": "push_subscriptions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"p256dh": {
+					"name": "p256dh",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"auth": {
+					"name": "auth",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"push_subscriptions_user_endpoint_idx": {
+					"name": "push_subscriptions_user_endpoint_idx",
+					"columns": ["user_id", "endpoint"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"push_subscriptions_user_id_app_users_id_fk": {
+					"name": "push_subscriptions_user_id_app_users_id_fk",
+					"tableFrom": "push_subscriptions",
+					"tableTo": "app_users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"transactions": {
+			"name": "transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"from_user_id": {
+					"name": "from_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"to_user_id": {
+					"name": "to_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"unit_code": {
+					"name": "unit_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pending_qr_id": {
+					"name": "pending_qr_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"transactions_from_user_id_app_users_id_fk": {
+					"name": "transactions_from_user_id_app_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "app_users",
+					"columnsFrom": ["from_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_to_user_id_app_users_id_fk": {
+					"name": "transactions_to_user_id_app_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "app_users",
+					"columnsFrom": ["to_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_pending_qr_id_pending_qr_id_fk": {
+					"name": "transactions_pending_qr_id_pending_qr_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "pending_qr",
+					"columnsFrom": ["pending_qr_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"phone_number": {
+					"name": "phone_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phone_number_verified": {
+					"name": "phone_number_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/sqlite/meta/_journal.json
+++ b/drizzle/sqlite/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1776351613578,
 			"tag": "0004_organic_ezekiel",
 			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "6",
+			"when": 1779973553045,
+			"tag": "0005_boring_justice",
+			"breakpoints": true
 		}
 	]
 }

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -12,5 +12,4 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const E2E_DB_FILE = path.resolve(__dirname, '..', 'test.db');
 export const E2E_AUTH_SECRET = 'e2e-test-only-better-auth-secret-not-for-production!!';
 export const E2E_BASE_URL = 'http://localhost:5174';
-export const E2E_QR_JWT_SECRET = 'e2e-test-only-secret-do-not-use-in-production!!';
 export const E2E_APP_NAME = process.env.PUBLIC_APP_NAME || 'Mutuvia';

--- a/e2e/onboarding.test.ts
+++ b/e2e/onboarding.test.ts
@@ -84,6 +84,6 @@ test.describe.serial('Onboarding flow', () => {
 
 		// Now re-visit onboarding — should redirect straight to /home
 		await page.goto('/onboarding');
-		await expect(page).toHaveURL(/\/home/);
+		await page.waitForURL(/\/home/, { timeout: 10_000 });
 	});
 });

--- a/e2e/pending-item-navigation.test.ts
+++ b/e2e/pending-item-navigation.test.ts
@@ -55,8 +55,8 @@ test.describe.serial('Pending item navigation', () => {
 		const now = Math.floor(Date.now() / 1000);
 		sqlite
 			.prepare(
-				`INSERT INTO pending_qr (id, initiating_user_id, direction, amount, status, created_at, expires_at)
-				 VALUES (?, ?, 'receive', 750, 'pending', ?, ?)`
+				`INSERT INTO pending_qr (id, initiating_user_id, direction, amount, initiator_name, status, created_at, expires_at)
+				 VALUES (?, ?, 'receive', 750, 'Test User', 'pending', ?, ?)`
 			)
 			.run(qrId, appUserId, now, now + 600);
 

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -2,9 +2,7 @@ import type { Page, BrowserContext } from '@playwright/test';
 import { test as base } from '@playwright/test';
 import { basename } from 'path';
 import type { TestHelpers } from 'better-auth/plugins';
-import * as jose from 'jose';
 import { auth, sqlite } from './auth.js';
-import { E2E_BASE_URL, E2E_QR_JWT_SECRET } from './config.js';
 import pkg from '../package.json' with { type: 'json' };
 
 export { expect } from '@playwright/test';
@@ -47,8 +45,8 @@ export function getAppUserId(betterAuthUserId: string): string {
 }
 
 /**
- * Insert a pending QR row and sign a JWT for it. Returns { token, qrId }.
- * Uses the same JWT format as src/lib/server/qr.ts (HS256, issuer=appUrl).
+ * Insert a pending QR row and return the UUID as the token. Returns { token, qrId }
+ * where token === qrId (the UUID used directly in the /accept/[token] URL).
  *
  * Pass an optional options object to override the defaults:
  *   - `direction` (default: `'send'`)
@@ -64,21 +62,12 @@ export async function createPendingQr(
 
 	sqlite
 		.prepare(
-			`INSERT INTO pending_qr (id, initiating_user_id, direction, amount, status, created_at, expires_at)
-			 VALUES (?, ?, ?, ?, 'pending', ?, ?)`
+			`INSERT INTO pending_qr (id, initiating_user_id, direction, amount, initiator_name, status, created_at, expires_at)
+			 VALUES (?, ?, ?, ?, ?, 'pending', ?, ?)`
 		)
-		.run(qrId, initiatingAppUserId, direction, amount, now, now + 600);
+		.run(qrId, initiatingAppUserId, direction, amount, senderName, now, now + 600);
 
-	const secret = new TextEncoder().encode(E2E_QR_JWT_SECRET);
-	const token = await new jose.SignJWT({ amt: amount, dir: direction, dn: senderName })
-		.setProtectedHeader({ alg: 'HS256' })
-		.setJti(qrId)
-		.setIssuer(E2E_BASE_URL)
-		.setIssuedAt()
-		.setExpirationTime('600s')
-		.sign(secret);
-
-	return { token, qrId };
+	return { token: qrId, qrId };
 }
 
 // ── OTP helpers ───────────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.14.0",
 		"globals": "^17.3.0",
-		"jose": "^6.2.2",
 		"jsdom": "^29.0.1",
 		"jsrepo": "^3.7.0",
 		"mode-watcher": "^1.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
-import { E2E_DB_FILE, E2E_AUTH_SECRET, E2E_BASE_URL, E2E_QR_JWT_SECRET } from './e2e/config.js';
+import { E2E_DB_FILE, E2E_AUTH_SECRET, E2E_BASE_URL } from './e2e/config.js';
 
 export default defineConfig({
 	testDir: './e2e',
@@ -22,8 +22,7 @@ export default defineConfig({
 			ORIGIN: E2E_BASE_URL,
 			APP_URL: E2E_BASE_URL,
 			BETTER_AUTH_SECRET: E2E_AUTH_SECRET,
-			DB_FILE_NAME: E2E_DB_FILE,
-			QR_JWT_SECRET: E2E_QR_JWT_SECRET
+			DB_FILE_NAME: E2E_DB_FILE
 		},
 		stdout: 'pipe',
 		stderr: 'pipe',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -31,13 +31,6 @@ export const config = {
 	get communityDocUrl() {
 		return publicEnv.PUBLIC_COMMUNITY_DOC_URL || '';
 	},
-	get qrJwtSecret() {
-		const secret = env.QR_JWT_SECRET;
-		if (!secret || secret.length < 32) {
-			throw new Error('QR_JWT_SECRET must be at least 32 characters');
-		}
-		return secret;
-	},
 	get preludeApiToken() {
 		return env.PRELUDE_API_TOKEN || '';
 	},

--- a/src/lib/server/db.pg.ts
+++ b/src/lib/server/db.pg.ts
@@ -2,7 +2,7 @@
 
 import { drizzle } from 'drizzle-orm/bun-sql';
 import { config } from '$lib/config';
-import * as schema from './schema';
+import * as schema from './schema.pg';
 
 export const db = drizzle({ connection: { url: config.databaseUrl }, schema });
 export const sqlite = null;

--- a/src/lib/server/db.sqlite.ts
+++ b/src/lib/server/db.sqlite.ts
@@ -3,7 +3,7 @@
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
 import { config } from '$lib/config';
-import * as schema from './schema';
+import * as schema from './schema.sqlite';
 
 export const sqlite = new Database(config.dbFileName);
 sqlite.exec('PRAGMA journal_mode = WAL;');

--- a/src/lib/server/qr.ts
+++ b/src/lib/server/qr.ts
@@ -1,47 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import * as jose from 'jose';
 import { config } from '$lib/config';
 
-const getSecret = () => {
-	const secret = process.env.QR_JWT_SECRET;
-	if (!secret || secret.length < 32) {
-		throw new Error('QR_JWT_SECRET must be at least 32 characters');
-	}
-	return new TextEncoder().encode(secret);
-};
-
-interface QrPayload {
-	jti: string;
-	amt: number;
-	dir: 'send' | 'receive';
-	dn: string;
-}
-
-export async function signQrToken(payload: QrPayload, ttlSeconds: number): Promise<string> {
-	return new jose.SignJWT({ amt: payload.amt, dir: payload.dir, dn: payload.dn })
-		.setProtectedHeader({ alg: 'HS256' })
-		.setJti(payload.jti)
-		.setIssuer(config.appUrl)
-		.setIssuedAt()
-		.setExpirationTime(`${ttlSeconds}s`)
-		.sign(getSecret());
-}
-
-export async function verifyQrToken(token: string): Promise<QrPayload & { exp: number }> {
-	const { payload } = await jose.jwtVerify(token, getSecret(), {
-		issuer: config.appUrl
-	});
-
-	return {
-		jti: payload.jti!,
-		amt: payload.amt as number,
-		dir: payload.dir as 'send' | 'receive',
-		dn: payload.dn as string,
-		exp: payload.exp!
-	};
-}
-
-export function buildQrUrl(token: string): string {
-	return `${config.appUrl}/accept/${token}`;
+export function buildQrUrl(id: string): string {
+	return `${config.appUrl}/accept/${id}`;
 }

--- a/src/lib/server/schema.pg.ts
+++ b/src/lib/server/schema.pg.ts
@@ -104,7 +104,8 @@ export const pendingQr = pgTable('pending_qr', {
 	note: text('note'),
 	createdAt: timestamp('created_at').notNull(),
 	expiresAt: timestamp('expires_at').notNull(),
-	status: text('status', { enum: ['pending', 'completed', 'declined'] }).notNull()
+	status: text('status', { enum: ['pending', 'completed', 'declined'] }).notNull(),
+	initiatorName: text('initiator_name').notNull()
 });
 
 export const connections = pgTable(

--- a/src/lib/server/schema.sqlite.ts
+++ b/src/lib/server/schema.sqlite.ts
@@ -96,7 +96,8 @@ export const pendingQr = sqliteTable('pending_qr', {
 	note: text('note'),
 	createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 	expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
-	status: text('status', { enum: ['pending', 'completed', 'declined'] }).notNull()
+	status: text('status', { enum: ['pending', 'completed', 'declined'] }).notNull(),
+	initiatorName: text('initiator_name').notNull()
 });
 
 export const connections = sqliteTable(

--- a/src/routes/(app)/receive/+page.server.ts
+++ b/src/routes/(app)/receive/+page.server.ts
@@ -4,8 +4,7 @@ import { redirect, fail } from '@sveltejs/kit';
 import { db } from '$lib/server/db';
 import { pendingQr } from '$lib/server/schema';
 import { eq } from 'drizzle-orm';
-import { signQrToken, buildQrUrl } from '$lib/server/qr';
-import { randomUUID } from 'node:crypto';
+import { buildQrUrl } from '$lib/server/qr';
 import { config } from '$lib/config';
 import { currencyFractionDigits } from '$lib/server/currency';
 import { getPendingItemById } from '$lib/server/pending-qr';
@@ -35,13 +34,8 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 					isExpired: true
 				};
 			} else {
-				const remainingTtl = Math.floor((item.expiresAt.getTime() - Date.now()) / 1000);
-				const token = await signQrToken(
-					{ jti: item.id, amt: item.amount, dir: 'receive', dn: appUser.displayName },
-					remainingTtl
-				);
 				resumeQr = {
-					qrUrl: buildQrUrl(token),
+					qrUrl: buildQrUrl(item.id),
 					qrId: item.id,
 					expiresAt: item.expiresAt.toISOString(),
 					isExpired: false,
@@ -84,7 +78,7 @@ export const actions: Actions = {
 		const amount = Math.round(floatAmount * Math.pow(10, dp));
 		const ttl = config.qrTtlSeconds;
 		const now = new Date();
-		const qrId = randomUUID();
+		const qrId = crypto.randomUUID();
 
 		await db.insert(pendingQr).values({
 			id: qrId,
@@ -92,18 +86,14 @@ export const actions: Actions = {
 			direction: 'receive',
 			amount,
 			note,
+			initiatorName: displayName,
 			createdAt: now,
 			expiresAt: new Date(now.getTime() + ttl * 1000),
 			status: 'pending'
 		});
 
-		const token = await signQrToken(
-			{ jti: qrId, amt: amount, dir: 'receive', dn: displayName },
-			ttl
-		);
-
 		return {
-			qrUrl: buildQrUrl(token),
+			qrUrl: buildQrUrl(qrId),
 			qrId,
 			expiresAt: new Date(now.getTime() + ttl * 1000).toISOString(),
 			shareDescription: shareText(amount, note)

--- a/src/routes/(app)/send/+page.server.ts
+++ b/src/routes/(app)/send/+page.server.ts
@@ -4,8 +4,7 @@ import { redirect, fail } from '@sveltejs/kit';
 import { db } from '$lib/server/db';
 import { appUsers, pendingQr } from '$lib/server/schema';
 import { eq } from 'drizzle-orm';
-import { signQrToken, buildQrUrl } from '$lib/server/qr';
-import { randomUUID } from 'node:crypto';
+import { buildQrUrl } from '$lib/server/qr';
 import { config } from '$lib/config';
 import { currencyFractionDigits } from '$lib/server/currency';
 import { getPendingItemById } from '$lib/server/pending-qr';
@@ -36,13 +35,8 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 					isExpired: true
 				};
 			} else {
-				const remainingTtl = Math.floor((item.expiresAt.getTime() - Date.now()) / 1000);
-				const token = await signQrToken(
-					{ jti: item.id, amt: item.amount, dir: 'send', dn: appUser.displayName },
-					remainingTtl
-				);
 				resumeQr = {
-					qrUrl: buildQrUrl(token),
+					qrUrl: buildQrUrl(item.id),
 					qrId: item.id,
 					expiresAt: item.expiresAt.toISOString(),
 					isExpired: false,
@@ -92,7 +86,7 @@ export const actions: Actions = {
 		const amount = Math.round(floatAmount * Math.pow(10, dp));
 		const ttl = config.qrTtlSeconds;
 		const now = new Date();
-		const qrId = randomUUID();
+		const qrId = crypto.randomUUID();
 
 		await db.insert(pendingQr).values({
 			id: qrId,
@@ -100,15 +94,14 @@ export const actions: Actions = {
 			direction: 'send',
 			amount,
 			note,
+			initiatorName: displayName,
 			createdAt: now,
 			expiresAt: new Date(now.getTime() + ttl * 1000),
 			status: 'pending'
 		});
 
-		const token = await signQrToken({ jti: qrId, amt: amount, dir: 'send', dn: displayName }, ttl);
-
 		return {
-			qrUrl: buildQrUrl(token),
+			qrUrl: buildQrUrl(qrId),
 			qrId,
 			expiresAt: new Date(now.getTime() + ttl * 1000).toISOString(),
 			shareDescription: shareText(amount, note)

--- a/src/routes/accept/[token]/+page.server.ts
+++ b/src/routes/accept/[token]/+page.server.ts
@@ -2,31 +2,17 @@
 
 import { redirect, fail, error } from '@sveltejs/kit';
 import { db } from '$lib/server/db';
-import { pendingQr, transactions, appUsers } from '$lib/server/schema';
+import { pendingQr, transactions } from '$lib/server/schema';
 import { eq } from 'drizzle-orm';
-import { verifyQrToken } from '$lib/server/qr';
 import { getBalance, upsertConnection } from '$lib/server/balance';
 import { formatAmount } from '$lib/server/currency';
 import { config } from '$lib/config';
-import { randomUUID } from 'node:crypto';
 import { emit } from '$lib/server/sse-registry';
 import { sendPushToUser } from '$lib/server/push-sender';
 import type { PageServerLoad, Actions } from './$types';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
-	// Client-side pre-check hint: try to decode JWT claims without verification
-	let tokenData;
-	try {
-		tokenData = await verifyQrToken(params.token);
-	} catch {
-		return {
-			expired: true,
-			error: 'This link has expired or is invalid.'
-		};
-	}
-
-	// Look up the pending QR
-	const [qr] = await db.select().from(pendingQr).where(eq(pendingQr.id, tokenData.jti)).limit(1);
+	const [qr] = await db.select().from(pendingQr).where(eq(pendingQr.id, params.token)).limit(1);
 	if (!qr || qr.status !== 'pending' || qr.expiresAt < new Date()) {
 		return {
 			expired: true,
@@ -34,21 +20,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		};
 	}
 
-	// Get initiator info (needed for both authenticated and unauthenticated views)
-	const [initiator] = await db
-		.select()
-		.from(appUsers)
-		.where(eq(appUsers.id, qr.initiatingUserId))
-		.limit(1);
-
-	if (!initiator) {
-		return { expired: true, error: 'Initiator not found.' };
-	}
-
 	if (!locals.session || !locals.appUser) {
-		// Return enough info to show the transaction preview. qrId is included only for the
-		// Decline action; the Accept action enforces auth server-side and is not rendered here.
-		// The startFastTrack / startFullOnboarding actions handle the auth redirect.
 		return {
 			expired: false,
 			needsAuth: true,
@@ -57,7 +29,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 			amount: qr.amount,
 			formattedAmount: formatAmount(qr.amount),
 			note: qr.note,
-			initiatorName: initiator.displayName,
+			initiatorName: qr.initiatorName,
 			token: params.token
 		};
 	}
@@ -80,7 +52,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		amount: qr.amount,
 		formattedAmount: formatAmount(qr.amount),
 		note: qr.note,
-		initiatorName: initiator.displayName,
+		initiatorName: qr.initiatorName,
 		initiatorBalance: formatAmount(initiatorBalance),
 		token: params.token
 	};
@@ -139,7 +111,7 @@ export const actions: Actions = {
 		}
 
 		// Atomic settlement: insert transaction + update QR status + upsert connection
-		const txId = randomUUID();
+		const txId = crypto.randomUUID();
 
 		await db.insert(transactions).values({
 			id: txId,
@@ -163,20 +135,9 @@ export const actions: Actions = {
 		// formatAmount never throws — it falls back to a locale-independent string
 		// when Paraglide's AsyncLocalStorage context is unavailable.
 		const formattedAmt = formatAmount(qr.amount);
+		const initiatorName = qr.initiatorName;
 
-		let initiatorName = 'Someone';
-		try {
-			const [initiatingUser] = await db
-				.select({ displayName: appUsers.displayName })
-				.from(appUsers)
-				.where(eq(appUsers.id, qr.initiatingUserId))
-				.limit(1);
-			initiatorName = initiatingUser?.displayName ?? 'Someone';
-		} catch (err) {
-			console.error('Failed to look up initiating user for notification:', err);
-		}
-
-		const eventId = randomUUID();
+		const eventId = crypto.randomUUID();
 		const completedForInitiator = {
 			type: 'qr_completed' as const,
 			id: eventId,
@@ -186,7 +147,7 @@ export const actions: Actions = {
 		};
 		const completedForAcceptor = {
 			type: 'qr_completed' as const,
-			id: randomUUID(),
+			id: crypto.randomUUID(),
 			qrId: qr.id,
 			otherName: initiatorName,
 			formattedAmount: formattedAmt
@@ -208,15 +169,8 @@ export const actions: Actions = {
 		const data = await request.formData();
 		const qrId = data.get('qrId') as string;
 
-		// Verify the token to ensure the decline is bound to the correct QR code.
-		let tokenData;
-		try {
-			tokenData = await verifyQrToken(params.token);
-		} catch {
-			return fail(400, { error: 'Invalid or expired token.' });
-		}
-		if (!qrId || qrId !== tokenData.jti) {
-			return fail(400, { error: 'QR ID does not match token.' });
+		if (!qrId || qrId !== params.token) {
+			return fail(400, { error: 'Invalid QR ID.' });
 		}
 
 		const [qr] = await db
@@ -228,7 +182,7 @@ export const actions: Actions = {
 		await db.update(pendingQr).set({ status: 'declined' }).where(eq(pendingQr.id, qrId));
 
 		if (qr) {
-			const declinedEvent = { type: 'qr_declined' as const, id: randomUUID(), qrId };
+			const declinedEvent = { type: 'qr_declined' as const, id: crypto.randomUUID(), qrId };
 			emit(qr.initiatingUserId, declinedEvent);
 			sendPushToUser(qr.initiatingUserId, declinedEvent).catch((err) => {
 				console.error('Push notification failed for QR decline:', err);

--- a/src/routes/accept/[token]/page.server.test.ts
+++ b/src/routes/accept/[token]/page.server.test.ts
@@ -35,7 +35,6 @@ const {
 	sendPushMock,
 	formatAmountMock,
 	upsertConnectionMock,
-	verifyQrTokenMock,
 	redirectMock,
 	dbSelectMock,
 	dbInsertMock,
@@ -75,7 +74,6 @@ const {
 		sendPushMock: vi.fn().mockResolvedValue(undefined),
 		formatAmountMock: vi.fn().mockReturnValue('€10.00'),
 		upsertConnectionMock: vi.fn().mockResolvedValue(undefined),
-		verifyQrTokenMock: vi.fn(),
 		redirectMock,
 		dbSelectMock,
 		dbInsertMock,
@@ -100,7 +98,7 @@ vi.mock('$lib/server/balance', () => ({
 	getBalance: vi.fn().mockResolvedValue(0),
 	upsertConnection: upsertConnectionMock
 }));
-vi.mock('$lib/server/qr', () => ({ verifyQrToken: verifyQrTokenMock }));
+vi.mock('$lib/server/qr', () => ({}));
 vi.mock('$lib/config', () => ({
 	config: { unitCode: 'EUR', qrTtlSeconds: 300 }
 }));
@@ -110,9 +108,6 @@ vi.mock('@sveltejs/kit', () => ({
 	error: vi.fn((_status: number, msg: unknown) => {
 		throw new Error(typeof msg === 'string' ? msg : JSON.stringify(msg));
 	})
-}));
-vi.mock('node:crypto', () => ({
-	randomUUID: vi.fn(() => 'mock-uuid')
 }));
 vi.mock('$lib/server/db', () => ({
 	db: { select: dbSelectMock, insert: dbInsertMock, update: dbUpdateMock }
@@ -144,7 +139,8 @@ const pendingQrRecord = {
 	initiatingUserId: INITIATOR_ID,
 	direction: 'send' as const,
 	amount: 1000,
-	note: null
+	note: null,
+	initiatorName: 'Alice'
 };
 
 function makeAcceptEvent(overrides: Record<string, unknown> = {}) {
@@ -170,15 +166,15 @@ function makeAcceptEvent(overrides: Record<string, unknown> = {}) {
 function makeDeclineEvent() {
 	const formData = new FormData();
 	formData.set('qrId', QR_ID);
-	const request = new Request('http://localhost/accept/test-token', {
+	const request = new Request(`http://localhost/accept/${QR_ID}`, {
 		method: 'POST',
 		body: formData
 	});
 	return {
 		request,
-		params: { token: 'test-token' },
+		params: { token: QR_ID },
 		locals: {},
-		url: new URL('http://localhost/accept/test-token')
+		url: new URL(`http://localhost/accept/${QR_ID}`)
 	} as unknown as Parameters<(typeof actions)['decline']>[0];
 }
 
@@ -303,7 +299,6 @@ describe('settlement → notification fanout', () => {
 
 	describe('decline', () => {
 		it('emits qr_declined to initiator when the decline action is called', async () => {
-			verifyQrTokenMock.mockResolvedValue({ jti: QR_ID });
 			selectLimitFn.mockResolvedValueOnce([{ initiatingUserId: INITIATOR_ID }]);
 
 			await runAction(() => actions.decline(makeDeclineEvent()));


### PR DESCRIPTION
## Summary

- Replaces signed JWTs in QR accept URLs with plain UUIDs, shrinking URLs from ~230 to ~50 chars and producing far less dense, easier-to-scan QR codes
- Adds `initiator_name` (NOT NULL) to the `pending_qr` table — stored at creation time, eliminating two `appUsers` joins on the accept page
- Removes the `jose` dependency and the `QR_JWT_SECRET` env var entirely

The UUID itself is the capability token (128-bit entropy, same model as Google Docs/Notion share links). All payload data previously embedded in the JWT was already in the DB.

## Test plan

- [x] `bun run check` — 0 errors
- [x] `bun run test` — 187/187 unit tests pass
- [x] `bunx playwright test` — 77/81 pass (3 skipped, 1 pre-existing flaky in `onboarding.test.ts` that passes in isolation)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)