### PR TITLE
chore(release): v0.3.0 — reusable QR codes, easier-to-scan URLs, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2026-05-29
+
+### Added
+
+- **Reusable payment QR codes** — create a permanent QR code on the Receive screen; each scan starts a new transaction. Supports pause and archive states, and shows a live payment count to the merchant. ([#115](https://github.com/dokterbob/mutuvia/pull/115))
+
+### Changed
+
+- QR accept URLs now use short UUIDs instead of signed JWTs — significantly smaller, less-dense, easier-to-scan QR codes. Removes the `QR_JWT_SECRET` env var requirement. ([#114](https://github.com/dokterbob/mutuvia/pull/114))
+
+### Fixed
+
+- Sentry server-side error capture no longer crashes on Bun — switched server SDK init to `@sentry/bun`, which excludes Node.js-incompatible integrations. ([#117](https://github.com/dokterbob/mutuvia/pull/117))
+
+## [0.2.0] - 2026-05-04
+
+### Added
+
+- **Credential management** — add or change email and phone number directly from the Settings page with inline OTP verification. ([#106](https://github.com/dokterbob/mutuvia/pull/106))
+- **Spanish language support** — full `es` locale with translation key validation wired into `bun run lint`. ([#105](https://github.com/dokterbob/mutuvia/pull/105))
+- **What's new dialog** — shown automatically on first app load after a version update; skipped for new installs and repeat visits. ([#108](https://github.com/dokterbob/mutuvia/pull/108))
+- OG meta tags and PWA manifest screenshots for a richer browser install UI. ([#104](https://github.com/dokterbob/mutuvia/pull/104), [#107](https://github.com/dokterbob/mutuvia/pull/107))
+
+### Changed
+
+- Replaced the immediate-cancel X on pending transaction rows with a chevron navigation affordance; added a confirmation dialog before cancelling on the QR screens. ([#101](https://github.com/dokterbob/mutuvia/pull/101))
+
+### Fixed
+
+- Auth endpoints (phone OTP, email OTP, session management) now work on custom domains — removed `baseURL` from Better Auth config so the origin is always derived from the incoming request. ([#110](https://github.com/dokterbob/mutuvia/pull/110))
+- Route protection moved to `hooks.server.ts` to prevent null `appUser` crashes; SvelteKit runs layout and page loads in parallel so the layout redirect alone was not sufficient. ([#102](https://github.com/dokterbob/mutuvia/pull/102))
+
+## [0.1.0] - 2026-04-10
+
+Initial release.

--- a/messages/de.json
+++ b/messages/de.json
@@ -295,5 +295,6 @@
 	"whats_new_title": "Was ist neu",
 	"whats_new_dismiss": "Verstanden",
 	"whats_new_version_label": "Version {version}",
-	"whats_new_v0_2_0": "E-Mail und Telefonnummer in den Einstellungen verwalten\nSpanische Sprachunterstützung\nVerbesserte Navigation mit Zurück-Schaltfläche und Abbruchbestätigung"
+	"whats_new_v0_2_0": "E-Mail und Telefonnummer in den Einstellungen verwalten\nSpanische Sprachunterstützung\nVerbesserte Navigation mit Zurück-Schaltfläche und Abbruchbestätigung",
+	"whats_new_v0_3_0": "Wiederverwendbare Zahlungs-QR-Codes — erstelle einen permanenten Code für mehrfaches Scannen\nEinfacher zu scannende QR-Codes (kürzere, einfachere URLs)"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -308,5 +308,6 @@
 	"whats_new_title": "What's new",
 	"whats_new_dismiss": "Got it",
 	"whats_new_version_label": "Version {version}",
-	"whats_new_v0_2_0": "Manage your email and phone number in settings\nSpanish language support\nImproved navigation with back button and cancel confirmation"
+	"whats_new_v0_2_0": "Manage your email and phone number in settings\nSpanish language support\nImproved navigation with back button and cancel confirmation",
+	"whats_new_v0_3_0": "Reusable payment QR codes — create a permanent code for customers to scan multiple times\nEasier-to-scan QR codes (shorter, simpler URLs)"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -307,5 +307,6 @@
 	"whats_new_title": "Novedades",
 	"whats_new_dismiss": "Entendido",
 	"whats_new_version_label": "Versión {version}",
-	"whats_new_v0_2_0": "Gestiona tu correo electrónico y número de teléfono en la configuración\nSoporte para el idioma español\nNavegación mejorada con botón de retroceso y confirmación de cancelación"
+	"whats_new_v0_2_0": "Gestiona tu correo electrónico y número de teléfono en la configuración\nSoporte para el idioma español\nNavegación mejorada con botón de retroceso y confirmación de cancelación",
+	"whats_new_v0_3_0": "Códigos QR de pago reutilizables — crea un código permanente para que los clientes escaneen varias veces\nCódigos QR más fáciles de escanear (URLs más cortas y simples)"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -307,5 +307,6 @@
 	"whats_new_title": "Wat is er nieuw",
 	"whats_new_dismiss": "Begrepen",
 	"whats_new_version_label": "Versie {version}",
-	"whats_new_v0_2_0": "Beheer uw e-mail en telefoonnummer in instellingen\nSpaanse taalondersteuning\nVerbeterde navigatie met terugknop en annuleringsbevestiging"
+	"whats_new_v0_2_0": "Beheer uw e-mail en telefoonnummer in instellingen\nSpaanse taalondersteuning\nVerbeterde navigatie met terugknop en annuleringsbevestiging",
+	"whats_new_v0_3_0": "Herbruikbare betaal-QR-codes — maak een permanente code die klanten meerdere keren kunnen scannen\nMakkelijker te scannen QR-codes (kortere, eenvoudigere URL's)"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -307,5 +307,6 @@
 	"whats_new_title": "O que há de novo",
 	"whats_new_dismiss": "Entendi",
 	"whats_new_version_label": "Versão {version}",
-	"whats_new_v0_2_0": "Gerencie seu e-mail e número de telefone nas configurações\nSuporte ao idioma espanhol\nNavegação melhorada com botão de voltar e confirmação de cancelamento"
+	"whats_new_v0_2_0": "Gerencie seu e-mail e número de telefone nas configurações\nSuporte ao idioma espanhol\nNavegação melhorada com botão de voltar e confirmação de cancelamento",
+	"whats_new_v0_3_0": "QR codes de pagamento reutilizáveis — crie um código permanente para clientes escanearem várias vezes\nQR codes mais fáceis de escanear (URLs mais curtas e simples)"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mutuvia",
 	"private": true,
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"type": "module",
 	"scripts": {
 		"dev": "bun --bun vite dev",

--- a/src/lib/whats-new.test.ts
+++ b/src/lib/whats-new.test.ts
@@ -3,6 +3,7 @@
 import { describe, test, expect, vi } from 'vitest';
 
 vi.mock('$lib/paraglide/messages.js', () => ({
+	whats_new_v0_3_0: () => 'New Feature A\nNew Feature B',
 	whats_new_v0_2_0: () => 'Feature A\nFeature B'
 }));
 
@@ -18,7 +19,7 @@ describe('getUnseenEntries', () => {
 
 	describe('when lastSeenVersion matches the current version', () => {
 		test('returns no entries', () => {
-			const result = getUnseenEntries('0.2.0');
+			const result = getUnseenEntries('0.3.0');
 			expect(result).toHaveLength(0);
 		});
 	});

--- a/src/lib/whats-new.ts
+++ b/src/lib/whats-new.ts
@@ -16,7 +16,10 @@ export interface WhatsNewEntry {
  * 2. Add an entry here at the top of the array
  * 3. Bump version in package.json
  */
-export const changelog: WhatsNewEntry[] = [{ version: '0.2.0', content: m.whats_new_v0_2_0 }];
+export const changelog: WhatsNewEntry[] = [
+	{ version: '0.3.0', content: m.whats_new_v0_3_0 },
+	{ version: '0.2.0', content: m.whats_new_v0_2_0 }
+];
 
 /** Returns changelog entries the user has not yet seen. */
 export function getUnseenEntries(


### PR DESCRIPTION
## Summary

- Bumps `package.json` version `0.2.0` → `0.3.0`
- Adds `whats_new_v0_3_0` message key to all 5 locales (EN/PT/NL/DE/ES)
- Prepends v0.3.0 entry to the changelog array in `src/lib/whats-new.ts`
- Updates test mock and current-version assertion in `whats-new.test.ts`
- Creates `CHANGELOG.md` (Keep a Changelog format) covering v0.1.0–v0.3.0

## What's new in v0.3.0

- **Reusable payment QR codes** (#115) — permanent scannable codes on the Receive screen
- **Shorter QR URLs** (#114) — short UUIDs replace signed JWTs; smaller, easier-to-scan codes
- **Sentry/Bun fix** (#117) — server-side error capture no longer crashes on Bun

## Test plan

- [x] `bun run lint` — all 5 locales have matching translation keys, formatting clean
- [x] `bun run test` — 243 unit tests pass
- [ ] `bun run check` — type-check (requires Paraglide codegen from `bun run dev/build`)
- [ ] Manual: open app with `lastSeenVersion = '0.2.0'` → what's new dialog shows 2 bullets for v0.3.0; dismiss → does not reappear

**Note:** PT/NL/DE/ES translations are machine-assisted — please review for naturalness before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)