### PR TITLE
fix(qr): copy link copies URL only, not share message

### DIFF
--- a/e2e/copy-button.test.ts
+++ b/e2e/copy-button.test.ts
@@ -1,5 +1,5 @@
 import { expect, type BrowserContext } from '@playwright/test';
-import { test, goto, setupAuthenticatedUser } from './test-utils.js';
+import { test, goto, setupAuthenticatedUser, deleteTestUser } from './test-utils.js';
 
 // The UI-state suite below is skipped due to a Vite dev-server warm-up race:
 // copy-button.test.ts sorts first alphabetically, so it runs before Vite finishes
@@ -105,5 +105,9 @@ test.describe.serial('CopyButton clipboard content', () => {
 		} finally {
 			await ctx.close();
 		}
+	});
+
+	test.afterAll(async ({ email }) => {
+		await deleteTestUser(email('user'));
 	});
 });

--- a/e2e/copy-button.test.ts
+++ b/e2e/copy-button.test.ts
@@ -1,10 +1,10 @@
 import { expect, type BrowserContext } from '@playwright/test';
 import { test, goto, setupAuthenticatedUser } from './test-utils.js';
 
-// These tests are skipped due to a Vite dev-server warm-up race: copy-button.test.ts
-// sorts first alphabetically, so it runs before Vite finishes its initial
-// dependency-optimisation reload. By that point better-sqlite3 (used by the
-// test-side auth helper) hasn't finished setting up the schema, causing
+// The UI-state suite below is skipped due to a Vite dev-server warm-up race:
+// copy-button.test.ts sorts first alphabetically, so it runs before Vite finishes
+// its initial dependency-optimisation reload. By that point better-sqlite3 (used
+// by the test-side auth helper) hasn't finished setting up the schema, causing
 // "no such table: user" errors. Later test files (send-receive, share-button)
 // run after the server has stabilised and pass fine.
 //
@@ -87,6 +87,10 @@ test.describe.serial('CopyButton clipboard content', () => {
 		const page = await ctx.newPage();
 		try {
 			await goto(page, '/send');
+			// Fresh user on first /send visit sees a consent step before the amount form
+			await expect(page.getByRole('button', { name: "I understand, let's go" })).toBeVisible();
+			await page.getByRole('button', { name: "I understand, let's go" }).click();
+			await expect(page.getByRole('heading', { name: 'Send' })).toBeVisible();
 			await page.locator('input[name="amount"]').fill('10');
 			await page.getByRole('button', { name: 'Generate QR' }).click();
 

--- a/e2e/copy-button.test.ts
+++ b/e2e/copy-button.test.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { expect, type BrowserContext } from '@playwright/test';
+import { test, goto, setupAuthenticatedUser } from './test-utils.js';
 
 // These tests are skipped due to a Vite dev-server warm-up race: copy-button.test.ts
 // sorts first alphabetically, so it runs before Vite finishes its initial
@@ -36,5 +37,69 @@ test.describe.skip('CopyButton', () => {
 		await page.locator('input[name="amount"]').fill('5');
 		await page.getByRole('button', { name: 'Generate QR' }).click();
 		await expect(page.getByRole('button', { name: /copy link/i })).toBeVisible();
+	});
+});
+
+test.describe.serial('CopyButton clipboard content', () => {
+	let storage: Awaited<ReturnType<BrowserContext['storageState']>>;
+
+	test.beforeAll(async ({ browser, email }, testInfo) => {
+		const baseURL = testInfo.project.use.baseURL!;
+		const ctx = await browser.newContext({ baseURL });
+		await setupAuthenticatedUser(ctx, email('user'), 'Copy Test User');
+		storage = await ctx.storageState();
+		await ctx.close();
+	});
+
+	test('Copy link on /receive copies only the QR URL', async ({ browser }, testInfo) => {
+		const baseURL = testInfo.project.use.baseURL!;
+		const ctx = await browser.newContext({
+			storageState: storage,
+			baseURL,
+			permissions: ['clipboard-read', 'clipboard-write']
+		});
+		const page = await ctx.newPage();
+		try {
+			await goto(page, '/receive');
+			await page.locator('input[name="amount"]').fill('5');
+			await page.getByRole('button', { name: 'Generate QR' }).click();
+
+			const urlText = page.getByText(/\/accept\//);
+			await expect(urlText).toBeVisible({ timeout: 10_000 });
+			const acceptUrl = (await urlText.textContent())!.trim();
+
+			await page.getByRole('button', { name: /copy link/i }).click();
+			const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+
+			expect(clipboard).toBe(acceptUrl);
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	test('Copy link on /send copies only the QR URL', async ({ browser }, testInfo) => {
+		const baseURL = testInfo.project.use.baseURL!;
+		const ctx = await browser.newContext({
+			storageState: storage,
+			baseURL,
+			permissions: ['clipboard-read', 'clipboard-write']
+		});
+		const page = await ctx.newPage();
+		try {
+			await goto(page, '/send');
+			await page.locator('input[name="amount"]').fill('10');
+			await page.getByRole('button', { name: 'Generate QR' }).click();
+
+			const urlText = page.getByText(/\/accept\//);
+			await expect(urlText).toBeVisible({ timeout: 10_000 });
+			const acceptUrl = (await urlText.textContent())!.trim();
+
+			await page.getByRole('button', { name: /copy link/i }).click();
+			const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+
+			expect(clipboard).toBe(acceptUrl);
+		} finally {
+			await ctx.close();
+		}
 	});
 });

--- a/e2e/pending-item-navigation.test.ts
+++ b/e2e/pending-item-navigation.test.ts
@@ -1,5 +1,12 @@
 import { expect, type BrowserContext } from '@playwright/test';
-import { test, goto, setupAuthenticatedUser, createPendingQr, getAppUserId } from './test-utils.js';
+import {
+	test,
+	goto,
+	setupAuthenticatedUser,
+	createPendingQr,
+	getAppUserId,
+	deleteTestUser
+} from './test-utils.js';
 import { sqlite } from './auth.js';
 
 test.describe.serial('Pending item navigation', () => {
@@ -84,5 +91,9 @@ test.describe.serial('Pending item navigation', () => {
 			sqlite.prepare(`DELETE FROM payment_requests WHERE id = ?`).run(qrId);
 			await ctx.close();
 		}
+	});
+
+	test.afterAll(async ({ email }) => {
+		await deleteTestUser(email('user'));
 	});
 });

--- a/e2e/qr-scanner.test.ts
+++ b/e2e/qr-scanner.test.ts
@@ -1,5 +1,5 @@
 import { expect, chromium, type BrowserContext } from '@playwright/test';
-import { test, setupAuthenticatedUser } from './test-utils.js';
+import { test, setupAuthenticatedUser, deleteTestUser } from './test-utils.js';
 import QRCode from 'qrcode';
 import { execSync } from 'child_process';
 import { mkdtempSync, unlinkSync, rmSync } from 'fs';
@@ -130,5 +130,10 @@ test.describe.serial('QR scanner E2E', () => {
 				// best-effort cleanup
 			}
 		}
+	});
+
+	test.afterAll(async ({ email }) => {
+		await deleteTestUser(email('sender'));
+		await deleteTestUser(email('scanner'));
 	});
 });

--- a/e2e/send-receive.test.ts
+++ b/e2e/send-receive.test.ts
@@ -1,5 +1,5 @@
 import { expect, type BrowserContext } from '@playwright/test';
-import { test, goto, setupAuthenticatedUser } from './test-utils.js';
+import { test, goto, setupAuthenticatedUser, deleteTestUser } from './test-utils.js';
 
 const SENDER_NAME = 'Test Sender';
 const RECEIVER_NAME = 'Test Receiver';
@@ -184,5 +184,10 @@ test.describe.serial('Send / Receive flow', () => {
 			await initiatorCtx.close();
 			await payerCtx.close();
 		}
+	});
+
+	test.afterAll(async ({ email }) => {
+		await deleteTestUser(email('sender'));
+		await deleteTestUser(email('receiver'));
 	});
 });

--- a/e2e/share-button.test.ts
+++ b/e2e/share-button.test.ts
@@ -1,5 +1,5 @@
 import { expect, type BrowserContext } from '@playwright/test';
-import { test, goto, setupAuthenticatedUser } from './test-utils.js';
+import { test, goto, setupAuthenticatedUser, deleteTestUser } from './test-utils.js';
 
 const TEST_NAME = 'Share Tester';
 
@@ -117,5 +117,9 @@ test.describe.serial('Share button', () => {
 		} finally {
 			await ctx.close();
 		}
+	});
+
+	test.afterAll(async ({ email }) => {
+		await deleteTestUser(email('user'));
 	});
 });

--- a/src/routes/(app)/receive/+page.svelte
+++ b/src/routes/(app)/receive/+page.svelte
@@ -55,7 +55,6 @@
 	let amountStep = $derived(Math.pow(10, -fractionDigits));
 	let amountPlaceholder = $derived((0).toFixed(fractionDigits));
 	let shareDescription = $state('');
-	let copyText = $derived(`${shareDescription}\n${qrUrl}`);
 
 	$effect(() => {
 		if (form?.qrUrl) {
@@ -270,7 +269,7 @@
 				{#if qrUrl}
 					<p class="mb-2 max-w-[280px] truncate text-xs text-muted-foreground">{qrUrl}</p>
 					<div class="mb-4 flex gap-2">
-						<CopyButton text={copyText} variant="outline" class="flex-1 rounded-xl text-sm">
+						<CopyButton text={qrUrl} variant="outline" class="flex-1 rounded-xl text-sm">
 							{m.qr_copy_link()}
 						</CopyButton>
 						{#if canShare}

--- a/src/routes/(app)/send/+page.svelte
+++ b/src/routes/(app)/send/+page.svelte
@@ -50,7 +50,6 @@
 	let amountStep = $derived(Math.pow(10, -fractionDigits));
 	let amountPlaceholder = $derived((0).toFixed(fractionDigits));
 	let shareDescription = $state('');
-	let copyText = $derived(`${shareDescription}\n${qrUrl}`);
 
 	$effect(() => {
 		if (form?.consented) {
@@ -266,7 +265,7 @@
 				{#if qrUrl}
 					<p class="mb-2 max-w-[280px] truncate text-xs text-muted-foreground">{qrUrl}</p>
 					<div class="mb-4 flex gap-2">
-						<CopyButton text={copyText} variant="outline" class="flex-1 rounded-xl text-sm">
+						<CopyButton text={qrUrl} variant="outline" class="flex-1 rounded-xl text-sm">
 							{m.qr_copy_link()}
 						</CopyButton>
 						{#if canShare}


### PR DESCRIPTION
## Summary

- Fixes #119: **Copy link** on the receive and send QR screens now copies only the clean URL, not the full share message prepended with a newline
- Removed the now-unused `copyText` derived in both pages; `shareDescription` is kept as-is for the **Share** button (`navigator.share`)

## Test plan

- [ ] Generate a QR on the **Receive** screen, click **Copy link**, paste — should be just the URL (no leading share text)
- [ ] Same on the **Send** screen
- [ ] Confirm **Share** button still triggers `navigator.share` with the descriptive message text
- [x] `bun run check` — 0 errors
- [x] `bun run test` — 243 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)